### PR TITLE
Handle missing R4 spec cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ Important implementation facts:
 - `scripts/fetch-spec.ts` defaults to fetching `r4` only
 - `scripts/fetch-examples.ts` refreshes committed R4 example fixtures from the official site when available; the site may rate-limit automation, so existing committed fixtures remain the deterministic test source
 - manifests are committed; extracted upstream package contents in `.local/` are not
+- code paths that require extracted spec inputs now fail with an explicit `MissingSpecPackageError` that tells the user to run `npm run fetch-spec`
+- spec-dependent generator suites skip cleanly on a fresh checkout when `.local/spec-cache/r4/package` is absent; fetching `r4` enables the full generator-side test coverage
 - generated files include timestamps, so normalized comparison logic matters for determinism checks
 
 ## Generated vs Handwritten Code

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ npm run list:r4-targets -- --summary
 
 Tracked implementation work lives in [`TASKS.md`](./TASKS.md).
 
+### Spec-dependent tests
+
+Some generator-side tests validate behavior against pinned extracted R4 spec inputs
+under `.local/spec-cache/r4/package`.
+
+Those extracted inputs are not committed. On a clean checkout, run:
+
+```bash
+npm run fetch-spec
+```
+
+before running the full generator-oriented test suite with `npm test`.
+
 ## Pre-release
 
 This repository is still pre-release.

--- a/TASKS.md
+++ b/TASKS.md
@@ -102,10 +102,12 @@ Track the work needed to align the repository with the current README.
 - [x] Add tests for choice field constraints
 - [ ] Add version-specific test coverage
 - [x] Add tests for generator determinism
+- [x] Fail clearly or skip intentionally when extracted spec cache is missing
 - [x] Add a schema test that rejects unknown top-level Patient fields
 - [x] Validate generated Patient fields directly against the pinned HL7 R4 StructureDefinition inputs
 - [x] Add R4 target-inventory regression tests
 - [x] Add generic official-example tests for generated R4 fixtures
+- [ ] Consider a dedicated CI profile that exercises spec-dependent suites after `npm run fetch-spec`
 - [ ] Investigate the four skipped official R4 examples that violate emitted base reference-target constraints
   Current skips:
   `DeviceMetric/devicemetric-example.json`

--- a/src/generator/sources/structuredefinition-r4.ts
+++ b/src/generator/sources/structuredefinition-r4.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { resolveRequiredSpecPackageRoot } from "../../spec/spec-cache.ts";
 import type {
 	BindingMetadata,
 	InvariantMetadata,
@@ -17,15 +17,6 @@ import {
 	sortProperties,
 } from "../model.ts";
 import { listR4GenerationTargetNames } from "../targets/r4.ts";
-
-type SpecManifest = {
-	fhirVersion: string;
-	packageName: string;
-	packageRoot: string;
-	packageVersion: string;
-	sourceUrl: string;
-	structureDefinitionGlob: string;
-};
 
 type StructureDefinition = {
 	abstract?: boolean;
@@ -134,8 +125,6 @@ type TerminologyIndex = {
 	valueSetsByUrl: Map<string, ValueSet>;
 };
 
-const moduleDir = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(moduleDir, "../../..");
 const fhirPathPrimitiveByCode = new Map<string, string>([
 	["http://hl7.org/fhirpath/System.Boolean", "boolean"],
 	["http://hl7.org/fhirpath/System.Date", "date"],
@@ -149,8 +138,7 @@ const fhirPathPrimitiveByCode = new Map<string, string>([
 export function buildStructureDefinitionR4Definitions(
 	scopeNames: Iterable<string> = listR4GenerationTargetNames(),
 ): StructureDefinitionBuildResult {
-	const manifest = loadManifest("r4");
-	const packageRoot = resolve(repoRoot, manifest.packageRoot);
+	const packageRoot = resolveRequiredSpecPackageRoot("r4");
 	const index = loadStructureDefinitionIndex(packageRoot);
 	const terminology = loadTerminologyIndex(packageRoot);
 	const primitivePatterns = loadPrimitivePatterns(index);
@@ -281,11 +269,6 @@ function collectElementTypeRefs(
 	}
 
 	return references;
-}
-
-function loadManifest(version: "r4"): SpecManifest {
-	const manifestPath = join(repoRoot, "src", "spec", version, "manifest.json");
-	return JSON.parse(readFileSync(manifestPath, "utf8")) as SpecManifest;
 }
 
 function loadStructureDefinitionIndex(

--- a/src/generator/targets/r4.ts
+++ b/src/generator/targets/r4.ts
@@ -1,10 +1,6 @@
 import { readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { repoRoot } from "../shared.ts";
-
-type SpecManifest = {
-	packageRoot: string;
-};
+import { join } from "node:path";
+import { resolveRequiredSpecPackageRoot } from "../../spec/spec-cache.ts";
 
 type StructureDefinition = {
 	abstract?: boolean;
@@ -43,8 +39,7 @@ export const r4AbstractTargetNames = [
 const abstractGenerationWhitelist = new Set<string>(r4AbstractTargetNames);
 
 export function loadR4TargetEntries(): R4TargetEntry[] {
-	const manifest = loadManifest("r4");
-	const packageRoot = resolve(repoRoot, manifest.packageRoot);
+	const packageRoot = resolveRequiredSpecPackageRoot("r4");
 
 	return readdirSync(packageRoot)
 		.filter(
@@ -140,9 +135,4 @@ function classifyTargetEntry(definition: StructureDefinition): R4TargetEntry {
 		type: definition.type ?? null,
 		url: definition.url ?? null,
 	};
-}
-
-function loadManifest(version: "r4"): SpecManifest {
-	const manifestPath = join(repoRoot, "src", "spec", version, "manifest.json");
-	return JSON.parse(readFileSync(manifestPath, "utf8")) as SpecManifest;
 }

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -48,6 +48,13 @@ npm run fetch-spec -- stu3
 npm run fetch-spec -- r4b r5
 ```
 
+On a clean checkout without extracted spec inputs, runtime/generated-output tests still
+pass, while spec-dependent generator suites skip with a message telling you to run
+`npm run fetch-spec`.
+
+Once `r4` has been fetched into `.local/spec-cache/r4/package`, the full current test
+suite runs, including the generator-side R4 inventory and provenance coverage.
+
 After refreshing:
 
 1. Update the matching `src/spec/<version>/manifest.json` if the pinned package changed.

--- a/src/spec/spec-cache.ts
+++ b/src/spec/spec-cache.ts
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { repoRoot as defaultRepoRoot } from "../generator/shared.ts";
+
+type SpecVersion = "stu3" | "r4" | "r4b" | "r5";
+
+export type SpecManifest = {
+	packageRoot: string;
+};
+
+export class MissingSpecPackageError extends Error {
+	readonly packageRoot: string;
+	readonly version: SpecVersion;
+
+	constructor(options: {
+		detail?: string;
+		packageRoot: string;
+		version: SpecVersion;
+	}) {
+		const detailSuffix = options.detail ? ` ${options.detail}` : "";
+
+		super(
+			[
+				`Missing extracted FHIR spec inputs for ${options.version} at ${options.packageRoot}.`,
+				"This repo commits pinned manifests, not extracted package contents.",
+				`Run \`npm run fetch-spec${options.version === "r4" ? "" : ` -- ${options.version}`}\` to populate ${relativePackageRoot(options.version)}.${detailSuffix}`,
+			].join(" "),
+		);
+
+		this.name = "MissingSpecPackageError";
+		this.packageRoot = options.packageRoot;
+		this.version = options.version;
+	}
+}
+
+export function resolveRequiredSpecPackageRoot(
+	version: SpecVersion,
+	options?: {
+		manifest?: SpecManifest;
+		repoRoot?: string;
+	},
+): string {
+	const manifest =
+		options?.manifest ?? loadManifest(version, options?.repoRoot);
+	const resolvedRepoRoot = options?.repoRoot ?? defaultRepoRoot;
+	const packageRoot = resolve(resolvedRepoRoot, manifest.packageRoot);
+
+	if (!existsSync(packageRoot)) {
+		throw new MissingSpecPackageError({
+			packageRoot,
+			version,
+		});
+	}
+
+	const structureDefinitionFiles = readdirSync(packageRoot).filter(
+		(filename) =>
+			filename.startsWith("StructureDefinition-") && filename.endsWith(".json"),
+	);
+
+	if (structureDefinitionFiles.length === 0) {
+		throw new MissingSpecPackageError({
+			detail:
+				"The extracted package root exists but does not contain any StructureDefinition-*.json files.",
+			packageRoot,
+			version,
+		});
+	}
+
+	return packageRoot;
+}
+
+function loadManifest(
+	version: SpecVersion,
+	repoRoot = defaultRepoRoot,
+): SpecManifest {
+	const manifestPath = join(repoRoot, "src", "spec", version, "manifest.json");
+	return JSON.parse(readFileSync(manifestPath, "utf8")) as SpecManifest;
+}
+
+function relativePackageRoot(version: SpecVersion): string {
+	return `.local/spec-cache/${version}/package`;
+}

--- a/tests/generator-provenance.test.ts
+++ b/tests/generator-provenance.test.ts
@@ -4,168 +4,179 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { writeNormalizedZodDefinitions } from "../src/generator/emit/zod.ts";
 import { buildStructureDefinitionR4Definitions } from "../src/generator/sources/structuredefinition-r4.ts";
+import { getR4SpecAvailability } from "./helpers/require-r4-spec.ts";
 
-describe("generated provenance headers", () => {
-	it("writes source provenance and preserves last generated when content is unchanged", () => {
-		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
-		const definitionsResult = buildStructureDefinitionR4Definitions([
-			"BackboneElement",
-		]);
+const r4SpecAvailability = getR4SpecAvailability();
+const describeR4Spec = r4SpecAvailability.available ? describe : describe.skip;
 
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-01T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
+describeR4Spec(
+	r4SpecAvailability.available
+		? "generated provenance headers"
+		: `generated provenance headers (${r4SpecAvailability.reason})`,
+	() => {
+		it("writes source provenance and preserves last generated when content is unchanged", () => {
+			const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
+			const definitionsResult = buildStructureDefinitionR4Definitions([
+				"BackboneElement",
+			]);
+
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-01T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
+
+			const definitionPath = join(outputDir, "BackboneElement.ts");
+			const firstContent = readFileSync(definitionPath, "utf8");
+			const firstStat = statSync(definitionPath);
+
+			expect(firstContent).toContain(
+				"// Profile: http://hl7.org/fhir/StructureDefinition/BackboneElement",
+			);
+			expect(firstContent).toContain("// Release: R4");
+			expect(firstContent).toContain("// Version: 4.0.1");
+			expect(firstContent).toContain(
+				"// Last generated: 2026-04-01T05:42:36.000Z",
+			);
+			expect(firstContent).not.toContain("Build ID");
+			expect(firstContent).not.toContain("Last updated");
+
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-02T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
+
+			const secondContent = readFileSync(definitionPath, "utf8");
+			const secondStat = statSync(definitionPath);
+
+			expect(secondContent).toBe(firstContent);
+			expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
 		});
 
-		const definitionPath = join(outputDir, "BackboneElement.ts");
-		const firstContent = readFileSync(definitionPath, "utf8");
-		const firstStat = statSync(definitionPath);
+		it("updates last generated when emitted content changes", () => {
+			const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
+			const definitionsResult = buildStructureDefinitionR4Definitions([
+				"BackboneElement",
+			]);
 
-		expect(firstContent).toContain(
-			"// Profile: http://hl7.org/fhir/StructureDefinition/BackboneElement",
-		);
-		expect(firstContent).toContain("// Release: R4");
-		expect(firstContent).toContain("// Version: 4.0.1");
-		expect(firstContent).toContain(
-			"// Last generated: 2026-04-01T05:42:36.000Z",
-		);
-		expect(firstContent).not.toContain("Build ID");
-		expect(firstContent).not.toContain("Last updated");
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-01T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
 
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-02T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
+			const definitionPath = join(outputDir, "BackboneElement.ts");
+			const updatedDefinitions = new Map(definitionsResult.definitions);
+			const backboneElement = updatedDefinitions.get("BackboneElement");
+
+			if (!backboneElement) {
+				throw new Error("Expected BackboneElement definition");
+			}
+
+			updatedDefinitions.set("BackboneElement", {
+				...backboneElement,
+				sourceMetadata: {
+					...backboneElement.sourceMetadata,
+					version: "4.0.2-test",
+				},
+			});
+
+			writeNormalizedZodDefinitions({
+				definitions: updatedDefinitions,
+				generatedAt: "2026-04-02T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
+
+			const updatedContent = readFileSync(definitionPath, "utf8");
+
+			expect(updatedContent).toContain(
+				"// Last generated: 2026-04-02T05:42:36.000Z",
+			);
+			expect(updatedContent).toContain("// Version: 4.0.2-test");
+			expect(updatedContent).not.toContain(
+				"// Last generated: 2026-04-01T05:42:36.000Z",
+			);
 		});
 
-		const secondContent = readFileSync(definitionPath, "utf8");
-		const secondStat = statSync(definitionPath);
+		it("omits source descriptions from generated schema fields", () => {
+			const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
+			const definitionsResult = buildStructureDefinitionR4Definitions([
+				"Patient",
+			]);
 
-		expect(secondContent).toBe(firstContent);
-		expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
-	});
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-01T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
 
-	it("updates last generated when emitted content changes", () => {
-		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
-		const definitionsResult = buildStructureDefinitionR4Definitions([
-			"BackboneElement",
-		]);
+			const definitionPath = join(outputDir, "Patient.ts");
+			const content = readFileSync(definitionPath, "utf8");
 
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-01T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
+			expect(content).toContain(
+				"_active: z.lazy(getElementSchema).optional(),",
+			);
+			expect(content).toContain("birthDate: fhirDate().optional(),");
+			expect(content).toContain('resourceType: z.literal("Patient"),');
+			expect(content).not.toContain(".describe(");
 		});
 
-		const definitionPath = join(outputDir, "BackboneElement.ts");
-		const updatedDefinitions = new Map(definitionsResult.definitions);
-		const backboneElement = updatedDefinitions.get("BackboneElement");
+		it("writes source descriptions as JSDoc on generated model types", () => {
+			const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
+			const definitionsResult = buildStructureDefinitionR4Definitions([
+				"Patient",
+			]);
 
-		if (!backboneElement) {
-			throw new Error("Expected BackboneElement definition");
-		}
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-01T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
 
-		updatedDefinitions.set("BackboneElement", {
-			...backboneElement,
-			sourceMetadata: {
-				...backboneElement.sourceMetadata,
-				version: "4.0.2-test",
-			},
+			const definitionPath = join(outputDir, "Patient.ts");
+			const content = readFileSync(definitionPath, "utf8");
+
+			expect(content).toContain(
+				"/** Demographics and other administrative information about an individual or animal receiving care or other health-related services. */",
+			);
+			expect(content).toContain(
+				"\t/** The date of birth for the individual. */\n\tbirthDate?: string;",
+			);
+			expect(content).toContain(
+				'\t/** This is a Patient resource. */\n\tresourceType: "Patient";',
+			);
 		});
 
-		writeNormalizedZodDefinitions({
-			definitions: updatedDefinitions,
-			generatedAt: "2026-04-02T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
+		it("emits shared helpers for regex-backed string primitives", () => {
+			const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
+			const definitionsResult = buildStructureDefinitionR4Definitions(["Meta"]);
+
+			writeNormalizedZodDefinitions({
+				definitions: definitionsResult.definitions,
+				generatedAt: "2026-04-01T05:42:36.000Z",
+				outputDir,
+				primitivePatterns: definitionsResult.primitivePatterns,
+			});
+
+			const definitionPath = join(outputDir, "Meta.ts");
+			const content = readFileSync(definitionPath, "utf8");
+
+			expect(content).toContain('from "../shared/fhir-primitives";');
+			expect(content).toContain("fhirCanonical");
+			expect(content).toContain("fhirId");
+			expect(content).toContain("fhirInstant");
+			expect(content).toContain("fhirString");
+			expect(content).toContain("fhirUri");
+			expect(content).toContain("profile: fhirCanonical().array().optional(),");
+			expect(content).toContain("id: fhirString().optional(),");
+			expect(content).toContain("source: fhirUri().optional(),");
 		});
-
-		const updatedContent = readFileSync(definitionPath, "utf8");
-
-		expect(updatedContent).toContain(
-			"// Last generated: 2026-04-02T05:42:36.000Z",
-		);
-		expect(updatedContent).toContain("// Version: 4.0.2-test");
-		expect(updatedContent).not.toContain(
-			"// Last generated: 2026-04-01T05:42:36.000Z",
-		);
-	});
-
-	it("omits source descriptions from generated schema fields", () => {
-		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
-		const definitionsResult = buildStructureDefinitionR4Definitions([
-			"Patient",
-		]);
-
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-01T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
-		});
-
-		const definitionPath = join(outputDir, "Patient.ts");
-		const content = readFileSync(definitionPath, "utf8");
-
-		expect(content).toContain("_active: z.lazy(getElementSchema).optional(),");
-		expect(content).toContain("birthDate: fhirDate().optional(),");
-		expect(content).toContain('resourceType: z.literal("Patient"),');
-		expect(content).not.toContain(".describe(");
-	});
-
-	it("writes source descriptions as JSDoc on generated model types", () => {
-		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
-		const definitionsResult = buildStructureDefinitionR4Definitions([
-			"Patient",
-		]);
-
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-01T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
-		});
-
-		const definitionPath = join(outputDir, "Patient.ts");
-		const content = readFileSync(definitionPath, "utf8");
-
-		expect(content).toContain(
-			"/** Demographics and other administrative information about an individual or animal receiving care or other health-related services. */",
-		);
-		expect(content).toContain(
-			"\t/** The date of birth for the individual. */\n\tbirthDate?: string;",
-		);
-		expect(content).toContain(
-			'\t/** This is a Patient resource. */\n\tresourceType: "Patient";',
-		);
-	});
-
-	it("emits shared helpers for regex-backed string primitives", () => {
-		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-provenance-"));
-		const definitionsResult = buildStructureDefinitionR4Definitions(["Meta"]);
-
-		writeNormalizedZodDefinitions({
-			definitions: definitionsResult.definitions,
-			generatedAt: "2026-04-01T05:42:36.000Z",
-			outputDir,
-			primitivePatterns: definitionsResult.primitivePatterns,
-		});
-
-		const definitionPath = join(outputDir, "Meta.ts");
-		const content = readFileSync(definitionPath, "utf8");
-
-		expect(content).toContain('from "../shared/fhir-primitives";');
-		expect(content).toContain("fhirCanonical");
-		expect(content).toContain("fhirId");
-		expect(content).toContain("fhirInstant");
-		expect(content).toContain("fhirString");
-		expect(content).toContain("fhirUri");
-		expect(content).toContain("profile: fhirCanonical().array().optional(),");
-		expect(content).toContain("id: fhirString().optional(),");
-		expect(content).toContain("source: fhirUri().optional(),");
-	});
-});
+	},
+);

--- a/tests/helpers/require-r4-spec.ts
+++ b/tests/helpers/require-r4-spec.ts
@@ -1,0 +1,27 @@
+import {
+	MissingSpecPackageError,
+	resolveRequiredSpecPackageRoot,
+} from "../../src/spec/spec-cache.ts";
+
+export function getR4SpecAvailability(): {
+	available: boolean;
+	reason: string | null;
+} {
+	try {
+		resolveRequiredSpecPackageRoot("r4");
+
+		return {
+			available: true,
+			reason: null,
+		};
+	} catch (error) {
+		if (error instanceof MissingSpecPackageError) {
+			return {
+				available: false,
+				reason: error.message,
+			};
+		}
+
+		throw error;
+	}
+}

--- a/tests/r4-patient-sd.test.ts
+++ b/tests/r4-patient-sd.test.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import { buildRuntimeSchemas } from "../src/generator/emit/zod.ts";
 import { buildStructureDefinitionR4Definitions } from "../src/generator/sources/structuredefinition-r4.ts";
+import { getR4SpecAvailability } from "./helpers/require-r4-spec.ts";
 
 const fixturesDir = resolve(
 	process.cwd(),
@@ -12,11 +13,9 @@ const fixturesDir = resolve(
 	"Patient",
 );
 
-const initialDefinitionsResult = buildStructureDefinitionR4Definitions();
-let patientSchema = buildRuntimeSchemas(
-	initialDefinitionsResult.definitions,
-	initialDefinitionsResult.primitivePatterns,
-).Patient;
+let patientSchema:
+	| { safeParse: (input: unknown) => { success: boolean } }
+	| undefined;
 
 function validatePatientPayload(
 	patientSchema: { safeParse: (input: unknown) => { success: boolean } },
@@ -52,164 +51,177 @@ function validatePatientPayload(
 	return patientSchema.safeParse(input);
 }
 
-describe("R4 SD-backed Patient schema", () => {
-	beforeAll(() => {
-		const definitionsResult = buildStructureDefinitionR4Definitions();
-		patientSchema = buildRuntimeSchemas(
-			definitionsResult.definitions,
-			definitionsResult.primitivePatterns,
-		).Patient;
-	});
+const r4SpecAvailability = getR4SpecAvailability();
+const describeR4Spec = r4SpecAvailability.available ? describe : describe.skip;
 
-	for (const filename of readdirSync(fixturesDir).sort()) {
-		if (!filename.endsWith(".json")) {
-			continue;
+describeR4Spec(
+	r4SpecAvailability.available
+		? "R4 SD-backed Patient schema"
+		: `R4 SD-backed Patient schema (${r4SpecAvailability.reason})`,
+	() => {
+		beforeAll(() => {
+			const definitionsResult = buildStructureDefinitionR4Definitions();
+			patientSchema = buildRuntimeSchemas(
+				definitionsResult.definitions,
+				definitionsResult.primitivePatterns,
+			).Patient;
+		});
+
+		for (const filename of readdirSync(fixturesDir).sort()) {
+			if (!filename.endsWith(".json")) {
+				continue;
+			}
+
+			it(`parses ${filename}`, () => {
+				const fixturePath = join(fixturesDir, filename);
+				const input = JSON.parse(readFileSync(fixturePath, "utf8")) as unknown;
+				const result = validatePatientPayload(requirePatientSchema(), input);
+
+				expect(result.success).toBe(true);
+			});
 		}
 
-		it(`parses ${filename}`, () => {
-			const fixturePath = join(fixturesDir, filename);
-			const input = JSON.parse(readFileSync(fixturePath, "utf8")) as unknown;
-			const result = validatePatientPayload(
-				patientSchema as {
-					safeParse: (input: unknown) => { success: boolean };
+		it("rejects a top-level animal property", () => {
+			const result = requirePatientSchema().safeParse({
+				animal: {
+					species: {
+						text: "dog",
+					},
 				},
-				input,
-			);
+				resourceType: "Patient",
+			});
 
-			expect(result.success).toBe(true);
+			expect(result.success).toBe(false);
 		});
+
+		it("requires communication.language", () => {
+			const result = requirePatientSchema().safeParse({
+				communication: [{}],
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		it("requires link.other", () => {
+			const result = requirePatientSchema().safeParse({
+				link: [
+					{
+						type: "refer",
+					},
+				],
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		it("requires link.type", () => {
+			const result = requirePatientSchema().safeParse({
+				link: [
+					{
+						other: {
+							reference: "Patient/example",
+						},
+					},
+				],
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects gender outside the required ValueSet binding", () => {
+			const result = requirePatientSchema().safeParse({
+				gender: "nonspecific",
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects link.type outside the required ValueSet binding", () => {
+			const result = requirePatientSchema().safeParse({
+				link: [
+					{
+						other: {
+							reference: "Patient/example",
+						},
+						type: "invalid-link-type",
+					},
+				],
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects constrained references outside the allowed target profiles", () => {
+			const result = requirePatientSchema().safeParse({
+				generalPractitioner: [
+					{
+						reference: "Observation/example",
+					},
+				],
+				managingOrganization: {
+					display: "Example org",
+				},
+				resourceType: "Patient",
+			});
+
+			expect(result.success).toBe(false);
+		});
+
+		describe("deceased[x]", () => {
+			it("accepts a single runtime choice", () => {
+				const result = requirePatientSchema().safeParse({
+					deceasedBoolean: true,
+					resourceType: "Patient",
+				});
+
+				expect(result.success).toBe(true);
+			});
+
+			it("rejects multiple runtime choices", () => {
+				const result = requirePatientSchema().safeParse({
+					deceasedBoolean: true,
+					deceasedDateTime: "2020-01-01T00:00:00Z",
+					resourceType: "Patient",
+				});
+
+				expect(result.success).toBe(false);
+			});
+		});
+
+		describe("multipleBirth[x]", () => {
+			it("accepts a single runtime choice", () => {
+				const result = requirePatientSchema().safeParse({
+					multipleBirthInteger: 2,
+					resourceType: "Patient",
+				});
+
+				expect(result.success).toBe(true);
+			});
+
+			it("rejects multiple runtime choices", () => {
+				const result = requirePatientSchema().safeParse({
+					multipleBirthBoolean: true,
+					multipleBirthInteger: 2,
+					resourceType: "Patient",
+				});
+
+				expect(result.success).toBe(false);
+			});
+		});
+	},
+);
+
+function requirePatientSchema(): {
+	safeParse: (input: unknown) => { success: boolean };
+} {
+	if (!patientSchema) {
+		throw new Error("Expected Patient schema to be initialized in beforeAll.");
 	}
 
-	it("rejects a top-level animal property", () => {
-		const result = patientSchema.safeParse({
-			animal: {
-				species: {
-					text: "dog",
-				},
-			},
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("requires communication.language", () => {
-		const result = patientSchema.safeParse({
-			communication: [{}],
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("requires link.other", () => {
-		const result = patientSchema.safeParse({
-			link: [
-				{
-					type: "refer",
-				},
-			],
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("requires link.type", () => {
-		const result = patientSchema.safeParse({
-			link: [
-				{
-					other: {
-						reference: "Patient/example",
-					},
-				},
-			],
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("rejects gender outside the required ValueSet binding", () => {
-		const result = patientSchema.safeParse({
-			gender: "nonspecific",
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("rejects link.type outside the required ValueSet binding", () => {
-		const result = patientSchema.safeParse({
-			link: [
-				{
-					other: {
-						reference: "Patient/example",
-					},
-					type: "invalid-link-type",
-				},
-			],
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	it("rejects constrained references outside the allowed target profiles", () => {
-		const result = patientSchema.safeParse({
-			generalPractitioner: [
-				{
-					reference: "Observation/example",
-				},
-			],
-			managingOrganization: {
-				display: "Example org",
-			},
-			resourceType: "Patient",
-		});
-
-		expect(result.success).toBe(false);
-	});
-
-	describe("deceased[x]", () => {
-		it("accepts a single runtime choice", () => {
-			const result = patientSchema.safeParse({
-				deceasedBoolean: true,
-				resourceType: "Patient",
-			});
-
-			expect(result.success).toBe(true);
-		});
-
-		it("rejects multiple runtime choices", () => {
-			const result = patientSchema.safeParse({
-				deceasedBoolean: true,
-				deceasedDateTime: "2020-01-01T00:00:00Z",
-				resourceType: "Patient",
-			});
-
-			expect(result.success).toBe(false);
-		});
-	});
-
-	describe("multipleBirth[x]", () => {
-		it("accepts a single runtime choice", () => {
-			const result = patientSchema.safeParse({
-				multipleBirthInteger: 2,
-				resourceType: "Patient",
-			});
-
-			expect(result.success).toBe(true);
-		});
-
-		it("rejects multiple runtime choices", () => {
-			const result = patientSchema.safeParse({
-				multipleBirthBoolean: true,
-				multipleBirthInteger: 2,
-				resourceType: "Patient",
-			});
-
-			expect(result.success).toBe(false);
-		});
-	});
-});
+	return patientSchema;
+}

--- a/tests/r4-targets.test.ts
+++ b/tests/r4-targets.test.ts
@@ -6,68 +6,77 @@ import {
 	r4AbstractTargetNames,
 	summarizeR4Targets,
 } from "../src/generator/targets/r4.ts";
+import { getR4SpecAvailability } from "./helpers/require-r4-spec.ts";
 
-describe("R4 target inventory", () => {
-	it("matches the pinned R4 inventory counts", () => {
-		const entries = loadR4TargetEntries();
-		const summary = summarizeR4Targets(entries);
+const r4SpecAvailability = getR4SpecAvailability();
+const describeR4Spec = r4SpecAvailability.available ? describe : describe.skip;
 
-		expect(summary.abstractGenerationWhitelist).toEqual([
-			"BackboneElement",
-			"DomainResource",
-			"Element",
-			"Resource",
-		]);
-		expect(summary.coreResourceCount).toBe(146);
-		expect(summary.profileResourceCount).toBe(43);
-		expect(summary.generationTargetCount).toBe(150);
-		expect(summary.concreteResourceCount).toBe(189);
-	});
+describeR4Spec(
+	r4SpecAvailability.available
+		? "R4 target inventory"
+		: `R4 target inventory (${r4SpecAvailability.reason})`,
+	() => {
+		it("matches the pinned R4 inventory counts", () => {
+			const entries = loadR4TargetEntries();
+			const summary = summarizeR4Targets(entries);
 
-	it("keeps core resource names unique while allowing profile name collisions", () => {
-		const entries = loadR4TargetEntries();
-		const coreNames = entries
-			.filter((entry) => entry.category === "core-resource")
-			.map((entry) => entry.name);
-		const profileNames = entries
-			.filter((entry) => entry.category === "profile-resource")
-			.map((entry) => entry.name);
+			expect(summary.abstractGenerationWhitelist).toEqual([
+				"BackboneElement",
+				"DomainResource",
+				"Element",
+				"Resource",
+			]);
+			expect(summary.coreResourceCount).toBe(146);
+			expect(summary.profileResourceCount).toBe(43);
+			expect(summary.generationTargetCount).toBe(150);
+			expect(summary.concreteResourceCount).toBe(189);
+		});
 
-		expect(new Set(coreNames).size).toBe(coreNames.length);
-		expect(new Set(profileNames).size).toBeLessThan(profileNames.length);
-		expect(
-			profileNames.filter((name) => name === "Example Lipid Profile").length,
-		).toBe(5);
-	});
+		it("keeps core resource names unique while allowing profile name collisions", () => {
+			const entries = loadR4TargetEntries();
+			const coreNames = entries
+				.filter((entry) => entry.category === "core-resource")
+				.map((entry) => entry.name);
+			const profileNames = entries
+				.filter((entry) => entry.category === "profile-resource")
+				.map((entry) => entry.name);
 
-	it("uses abstract bases plus all core resources as the default generation scope", () => {
-		const entries = loadR4TargetEntries();
-		const expectedScope = entries
-			.filter((entry) => entry.shouldGenerate)
-			.map((entry) => entry.name)
-			.sort((left, right) => left.localeCompare(right));
-		const actualScope = listR4GenerationTargetNames();
+			expect(new Set(coreNames).size).toBe(coreNames.length);
+			expect(new Set(profileNames).size).toBeLessThan(profileNames.length);
+			expect(
+				profileNames.filter((name) => name === "Example Lipid Profile").length,
+			).toBe(5);
+		});
 
-		expect(actualScope).toEqual(expectedScope);
-		expect(actualScope).toEqual(
-			expect.arrayContaining([...r4AbstractTargetNames]),
-		);
-		expect(actualScope).toContain("Patient");
-		expect(actualScope).toContain("Observation");
-		expect(actualScope).toContain("Resource");
-	});
+		it("uses abstract bases plus all core resources as the default generation scope", () => {
+			const entries = loadR4TargetEntries();
+			const expectedScope = entries
+				.filter((entry) => entry.shouldGenerate)
+				.map((entry) => entry.name)
+				.sort((left, right) => left.localeCompare(right));
+			const actualScope = listR4GenerationTargetNames();
 
-	it("builds a large definition closure from the default generation scope", () => {
-		const definitionsResult = buildStructureDefinitionR4Definitions();
-		const definitionNames = new Set(definitionsResult.definitions.keys());
+			expect(actualScope).toEqual(expectedScope);
+			expect(actualScope).toEqual(
+				expect.arrayContaining([...r4AbstractTargetNames]),
+			);
+			expect(actualScope).toContain("Patient");
+			expect(actualScope).toContain("Observation");
+			expect(actualScope).toContain("Resource");
+		});
 
-		expect(definitionsResult.definitions.size).toBeGreaterThan(650);
-		expect(definitionNames.has("Account")).toBe(true);
-		expect(definitionNames.has("Bundle")).toBe(true);
-		expect(definitionNames.has("Condition")).toBe(true);
-		expect(definitionNames.has("Encounter")).toBe(true);
-		expect(definitionNames.has("Observation")).toBe(true);
-		expect(definitionNames.has("Practitioner")).toBe(true);
-		expect(definitionNames.has("ValueSet")).toBe(true);
-	});
-});
+		it("builds a large definition closure from the default generation scope", () => {
+			const definitionsResult = buildStructureDefinitionR4Definitions();
+			const definitionNames = new Set(definitionsResult.definitions.keys());
+
+			expect(definitionsResult.definitions.size).toBeGreaterThan(650);
+			expect(definitionNames.has("Account")).toBe(true);
+			expect(definitionNames.has("Bundle")).toBe(true);
+			expect(definitionNames.has("Condition")).toBe(true);
+			expect(definitionNames.has("Encounter")).toBe(true);
+			expect(definitionNames.has("Observation")).toBe(true);
+			expect(definitionNames.has("Practitioner")).toBe(true);
+			expect(definitionNames.has("ValueSet")).toBe(true);
+		});
+	},
+);

--- a/tests/spec-cache.test.ts
+++ b/tests/spec-cache.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	MissingSpecPackageError,
+	resolveRequiredSpecPackageRoot,
+} from "../src/spec/spec-cache.ts";
+
+describe("spec cache guard", () => {
+	it("returns the resolved package root when extracted StructureDefinitions are present", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-spec-cache-"));
+		const packageRoot = join(repoRoot, ".local", "spec-cache", "r4", "package");
+
+		mkdirSync(packageRoot, { recursive: true });
+		writeFileSync(
+			join(packageRoot, "StructureDefinition-Patient.json"),
+			JSON.stringify({
+				name: "Patient",
+				resourceType: "StructureDefinition",
+			}),
+			"utf8",
+		);
+
+		expect(
+			resolveRequiredSpecPackageRoot("r4", {
+				manifest: {
+					packageRoot: ".local/spec-cache/r4/package",
+				},
+				repoRoot,
+			}),
+		).toBe(packageRoot);
+	});
+
+	it("throws a typed error with fetch instructions when extracted inputs are missing", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-spec-cache-"));
+
+		expect(() =>
+			resolveRequiredSpecPackageRoot("r4", {
+				manifest: {
+					packageRoot: ".local/spec-cache/r4/package",
+				},
+				repoRoot,
+			}),
+		).toThrowError(MissingSpecPackageError);
+
+		try {
+			resolveRequiredSpecPackageRoot("r4", {
+				manifest: {
+					packageRoot: ".local/spec-cache/r4/package",
+				},
+				repoRoot,
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(MissingSpecPackageError);
+			expect((error as Error).message).toContain(
+				"Missing extracted FHIR spec inputs for r4",
+			);
+			expect((error as Error).message).toContain(
+				join(repoRoot, ".local", "spec-cache", "r4", "package"),
+			);
+			expect((error as Error).message).toContain("npm run fetch-spec");
+			expect((error as Error).message).toContain(
+				"This repo commits pinned manifests, not extracted package contents.",
+			);
+			return;
+		}
+
+		throw new Error("Expected resolveRequiredSpecPackageRoot to throw.");
+	});
+
+	it("throws a typed error when the extracted package root exists but is not populated", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-spec-cache-"));
+		const packageRoot = join(repoRoot, ".local", "spec-cache", "r4", "package");
+
+		mkdirSync(packageRoot, { recursive: true });
+
+		expect(() =>
+			resolveRequiredSpecPackageRoot("r4", {
+				manifest: {
+					packageRoot: ".local/spec-cache/r4/package",
+				},
+				repoRoot,
+			}),
+		).toThrowError(MissingSpecPackageError);
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared spec-cache guard that raises a typed error with fetch instructions when extracted R4 inputs are missing
- skip spec-dependent generator suites cleanly on fresh checkouts while keeping direct error-path coverage
- clarify README, AGENTS, and spec docs around `.local/spec-cache` expectations and test behavior

## Testing
- npm test
- npm run typecheck
- npm run check
- npm run fetch-spec
- npm test