### PR TITLE
Update release workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ npm run fetch-spec -- stu3 r4b r5
 npm run list:stu3-targets -- --summary
 npm run list:r4-targets -- --summary
 npm run list:r4b-targets -- --summary
+npm run list:r5-targets -- --summary
+npm run list:targets -- r4 --summary
 npm run generate
 npm test
 npm run typecheck
@@ -76,10 +78,13 @@ npm run typecheck
 
 Important implementation facts:
 
-- `scripts/generate.ts` generates `stu3`, `r4`, `r4b`, and `r5`
+- `src/generator/versions.ts` is the central release registry for `stu3`, `r4`, `r4b`, and `r5`
+- `scripts/generate.ts`, `scripts/list-targets.ts`, and `scripts/fetch-examples.ts` resolve versions through the release registry
 - the default STU3 generation scope is all `core-resource` targets reported by `npm run list:stu3-targets -- --summary`, plus the abstract whitelist
 - the default R4 generation scope is all `core-resource` targets reported by `npm run list:r4-targets -- --summary`, plus the abstract whitelist
 - the default R4B generation scope is all `core-resource` targets reported by `npm run list:r4b-targets -- --summary`, plus the abstract whitelist
+- the default R5 generation scope is all `core-resource` targets reported by `npm run list:r5-targets -- --summary`, plus the abstract whitelist
+- target inventory, generation, example-page URL construction, and shared StructureDefinition normalization are implemented once on `FhirRelease` or its shared source normalizer
 - `scripts/fetch-spec.ts` defaults to fetching `r4` only
 - `scripts/fetch-examples.ts` refreshes committed STU3, R4, R4B, and R5 example fixtures from the official site when available; the site may rate-limit automation, so existing committed fixtures remain the deterministic test source
 - manifests are committed; extracted upstream package contents in `.local/` are not
@@ -176,6 +181,7 @@ When making changes, prefer:
 - deterministic output
 - explicit tests for schema behavior
 - updating docs when project reality changes
+- adding future FHIR versions through a small `FhirRelease` subclass plus thin compatibility wrappers, instead of copying version-specific generator logic
 
 If you change the pipeline, also consider updating:
 
@@ -188,7 +194,7 @@ If you change the pipeline, also consider updating:
 
 These are active areas, not settled design:
 
-- generating additional versions beyond R4
+- adding future FHIR versions beyond STU3, R4, R4B, and R5 through the release registry
 - handling inheritance safely in the presence of dependency cycles
 - replacing the current mixed type/schema export story with generated public TS models plus separate schema exports
 - deciding how primitive underscore fields should be modeled long-term

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Current repository status:
 - versioned subpath exports are wired
 - STU3, R4, R4B, and R5 generation are implemented and checked in under `src/stu3`, `src/r4`, `src/r4b`, and `src/r5`
 - package output is tree-shakeable ESM with side-effect-free metadata
-- default R4 generation covers the canonical core-resource set plus required dependencies
+- default generation for each supported FHIR version covers the canonical core-resource set plus required dependencies
 - build, lint, format, coverage, and test commands are configured
 - spec manifests are pinned for `stu3`, `r4`, `r4b`, and `r5`
 - real generated schema output currently exists for `stu3`, `r4`, `r4b`, and `r5`
@@ -106,6 +106,7 @@ npm run lint
 npm run coverage
 npm test
 npm run generate
+npm run list:targets -- r4 --summary
 npm run list:stu3-targets -- --summary
 npm run list:r4-targets -- --summary
 npm run list:r4b-targets -- --summary
@@ -207,7 +208,8 @@ There are no customers and no compatibility promises yet. Breaking changes are a
 
 ## Inspecting Generation Targets
 
-Use the target listing scripts to inspect which `StructureDefinition` entries are:
+Use the shared target listing script to inspect which `StructureDefinition`
+entries are:
 
 - core canonical resources
 - profile-like resource definitions
@@ -215,6 +217,21 @@ Use the target listing scripts to inspect which `StructureDefinition` entries ar
 - final generation targets
 
 Examples:
+
+```bash
+npm run list:targets -- stu3 --summary
+npm run list:targets -- stu3 --category core-resource --names-only
+npm run list:targets -- r4 --summary
+npm run list:targets -- r4 --category core-resource --names-only
+npm run list:targets -- r4 --category profile-resource --names-only
+npm run list:targets -- r4 --category generation-target --names-only
+npm run list:targets -- r4b --summary
+npm run list:targets -- r4b --category core-resource --names-only
+npm run list:targets -- r5 --summary
+npm run list:targets -- r5 --category core-resource --names-only
+```
+
+The version-specific wrappers remain available:
 
 ```bash
 npm run list:stu3-targets -- --summary
@@ -246,8 +263,9 @@ Supported output modes:
 
 Current generation policy:
 
-- `npm run generate` emits all canonical R4 core resources plus the abstract base whitelist and required dependencies
+- `npm run generate` defaults to R4 and emits all canonical R4 core resources plus the abstract base whitelist and required dependencies
 - `npm run generate -- stu3` emits all canonical STU3 core resources plus the abstract base whitelist and required dependencies
+- `npm run generate -- r4` emits all canonical R4 core resources plus the abstract base whitelist and required dependencies
 - `npm run generate -- r4b` emits all canonical R4B core resources plus the abstract base whitelist and required dependencies
 - `npm run generate -- r5` emits all canonical R5 core resources plus the abstract base whitelist and required dependencies
 - profile-resource definitions are intentionally excluded from generation for now
@@ -320,7 +338,7 @@ Possible future convenience layers such as builders should live above core, not 
 
 ```console
 /src
-  /generator        # codegen logic
+  /generator        # codegen logic, including the FhirRelease registry
   /spec             # raw FHIR definitions
   /r4
   /r4b
@@ -330,6 +348,7 @@ Possible future convenience layers such as builders should live above core, not 
 
 /scripts
   generate.ts
+  list-targets.ts
 
 /tests
 ```
@@ -364,6 +383,9 @@ Current implementation notes:
 
 - `npm run fetch-spec` defaults to `r4`
 - `npm run generate` defaults to `r4`
+- `scripts/generate.ts`, `scripts/list-targets.ts`, and `scripts/fetch-examples.ts` select versions through `src/generator/versions.ts`
+- `src/generator/versions.ts` owns release-specific target classification, abstract generation whitelists, example page URLs, and version-specific normalizer options
+- the StructureDefinition normalizer is shared across STU3, R4, R4B, and R5, with version wrapper files kept for import compatibility
 - `npm run generate -- stu3` generates STU3
 - `npm run generate -- r4` generates R4
 - `npm run generate -- r4b` generates R4B

--- a/TASKS.md
+++ b/TASKS.md
@@ -68,6 +68,12 @@ Track the work needed to align the repository with the current README.
 - [x] Implement generation entrypoint in `scripts/generate.ts`
 - [x] Replace the hand-maintained Patient-first R4 seed list with shared target discovery
 - [x] Default R4 generation to all canonical core resources plus required dependencies
+- [x] Default STU3, R4B, and R5 generation to all canonical core resources plus required dependencies
+- [x] Share generation, target inventory, example fetching, and StructureDefinition normalization through release classes
+  Current state:
+  `src/generator/versions.ts` defines the STU3, R4, R4B, and R5 release registry.
+  Version-specific generator, target, and StructureDefinition modules are now
+  thin compatibility adapters over the shared `FhirRelease` workflow.
 - [x] Exclude profile-resource definitions from generation until canonical-url-based naming is implemented
 
 ## Generated Schema Output
@@ -93,7 +99,7 @@ Track the work needed to align the repository with the current README.
   recursive composition make that cleaner.
 - [x] Teach the generator to emit named TypeScript models for generated definitions
   Current state:
-  generated STU3, R4, and R4B declaration tests assert named interfaces and
+  generated STU3, R4, R4B, and R5 declaration tests assert named interfaces and
   `z.ZodType<Model>` schema exports instead of `z.output<typeof Schema>`.
 - [x] Rename generated R4 schema exports to `*Schema` alongside the separate public model layer
 - [x] Preserve spec-defined inheritance relationships in generated TS models and schema exports where runtime initialization is safe
@@ -120,8 +126,18 @@ Track the work needed to align the repository with the current README.
 - [x] Validate generated Patient fields directly against the pinned HL7 R4 StructureDefinition inputs
 - [x] Add STU3 target-inventory regression tests
 - [x] Add R4 target-inventory regression tests
+- [x] Add R4B target-inventory regression tests
 - [x] Add R5 target-inventory regression tests
+- [x] Consolidate repeated target-inventory tests behind shared helpers
+  Current state:
+  version-specific target inventory suites call `tests/helpers/target-inventory-suite.ts`
+  with per-version expectations, while preserving separate STU3, R4, R4B, and R5
+  test files.
 - [x] Add generic official-example tests for generated R4 fixtures
+- [x] Consolidate repeated official-example validation behind shared helpers
+  Current state:
+  version-specific official-example suites call `tests/helpers/official-examples-suite.ts`
+  and share spec-cache availability checks through `tests/helpers/spec-availability.ts`.
 - [x] Download official STU3 example fixtures
   Current state:
   STU3 target discovery exists, committed STU3 official example fixtures are

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"format": "biome format --write .",
 		"generate": "node scripts/generate.ts",
 		"inspect:choice-groups": "node scripts/inspect-choice-groups.ts",
+		"list:targets": "node scripts/list-targets.ts",
 		"list:stu3-targets": "node scripts/list-stu3-targets.ts",
 		"list:r4-targets": "node scripts/list-r4-targets.ts",
 		"list:r4b-targets": "node scripts/list-r4b-targets.ts",

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -52,8 +52,16 @@ On a clean checkout without extracted spec inputs, runtime/generated-output test
 pass, while spec-dependent generator suites skip with a message telling you to run
 `npm run fetch-spec`.
 
-Once `r4` has been fetched into `.local/spec-cache/r4/package`, the full current test
-suite runs, including the generator-side R4 inventory and provenance coverage.
+Fetch every pinned version before running the full spec-dependent generator suite:
+
+```bash
+npm run fetch-spec
+npm run fetch-spec -- stu3 r4b r5
+```
+
+Once the relevant version has been fetched into `.local/spec-cache/<version>/package`,
+that version's generator-side inventory, provenance, and example-refresh tooling can
+read the pinned package inputs.
 
 After refreshing:
 


### PR DESCRIPTION
# Summary

Update repository docs to reflect the release-class FHIR version workflow and the shared target listing entrypoint. This keeps README, TASKS, AGENTS guidance, and spec-cache notes aligned with the merged generator architecture.

## Changes

- Document `src/generator/versions.ts` as the central STU3/R4/R4B/R5 release registry.
- Add `npm run list:targets` as the shared target inventory npm script and document the cross-version usage.
- Update task tracking and spec-cache guidance for all supported FHIR versions.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run list:targets -- r4 --summary
npm run check
git diff --check
```

## Docs

- [ ] No docs update needed
- [x] Docs updated
