### PR TITLE
Add configurable empty FHIR string handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ const patient: Patient = {
 }
 ```
 
+### Empty FHIR Strings
+
+FHIR `string` values reject empty strings by default. To accept real-world
+payloads that use empty strings for the FHIR `string` primitive, configure the
+root package before constructing or importing schemas that use `fhirString()`:
+
+```ts
+import { configureFhirString } from "@fhir-zod/core"
+
+configureFhirString({ allowEmpty: true })
+```
+
+This only affects the FHIR `string` primitive. Other primitives such as `date`,
+`dateTime`, `base64Binary`, `code`, `id`, and `uri` keep their default
+validation behavior.
+
 Target package shape:
 
 - export generated TypeScript interfaces/types for FHIR model shapes

--- a/TASKS.md
+++ b/TASKS.md
@@ -207,9 +207,11 @@ Track the work needed to align the repository with the current README.
 
 - [x] Confirm whether `animal` should remain in the generated R4 Patient schema based on the pinned HL7 source artifacts
 - [ ] Model primitive underscore fields as FHIR primitive extensions and compare the approach with `fhir.resources`
-- [ ] Decide whether to support lenient parsing of empty-string primitive values seen in real-world data even when they are invalid FHIR
-  Follow-up:
-  determine whether this belongs in core schema validation, an opt-in compatibility mode, or a separate normalization layer before validation.
+- [x] Decide whether to support lenient parsing of empty-string primitive values seen in real-world data even when they are invalid FHIR
+  Decision:
+  support this as an opt-in compatibility mode for only the FHIR `string`
+  primitive via `configureFhirString({ allowEmpty: true })`; other primitives
+  keep their default validation behavior.
 - [x] Validate whether `Reference` fields should stay generic or be constrained by the HL7 source definitions
 
 ## Reference Follow-Up

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
-export {};
+export {
+	configureFhirString,
+	type FhirStringConfiguration,
+} from "./shared/fhir-primitives";

--- a/src/shared/fhir-primitives.ts
+++ b/src/shared/fhir-primitives.ts
@@ -64,12 +64,27 @@ export const fhirInstantPattern =
 export const fhirInteger64Pattern = /[0]|[-+]?[1-9][0-9]*/;
 export const fhirOidPattern = /urn:oid:[0-2](\.(0|[1-9][0-9]*))+/;
 export const fhirStringPattern = /[ \r\n\t\S]+/;
+export const fhirStringAllowEmptyPattern = /^$|[ \r\n\t\S]+/;
 export const fhirTimePattern =
 	/^([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?$/;
 export const fhirUriPattern = /\S*/;
 export const fhirUrlPattern = /\S*/;
 export const fhirUuidPattern =
 	/^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export interface FhirStringConfiguration {
+	allowEmpty: boolean;
+}
+
+let fhirStringConfiguration: FhirStringConfiguration = {
+	allowEmpty: false,
+};
+
+export function configureFhirString(
+	configuration: FhirStringConfiguration,
+): void {
+	fhirStringConfiguration = { ...configuration };
+}
 
 export function fhirBase64Binary(): z.ZodType<string> {
 	return z.string().refine(isFhirBase64Binary);
@@ -108,7 +123,11 @@ export function fhirOid(): z.ZodString {
 }
 
 export function fhirString(): z.ZodString {
-	return withPattern(fhirStringPattern);
+	return withPattern(
+		fhirStringConfiguration.allowEmpty
+			? fhirStringAllowEmptyPattern
+			: fhirStringPattern,
+	);
 }
 
 export function fhirTime(): z.ZodString {

--- a/tests/fhir-primitives.test.ts
+++ b/tests/fhir-primitives.test.ts
@@ -1,6 +1,7 @@
+import { configureFhirString } from "@fhir-zod/core";
 import * as r4Schemas from "@fhir-zod/core/r4";
 import * as r4bSchemas from "@fhir-zod/core/r4b";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
 	fhirBase64Binary,
 	fhirCanonical,
@@ -18,6 +19,10 @@ import {
 } from "../src/shared/fhir-primitives.ts";
 
 describe("FHIR primitives", () => {
+	afterEach(() => {
+		configureFhirString({ allowEmpty: false });
+	});
+
 	describe("fhirId", () => {
 		it("accepts valid FHIR id values", () => {
 			const schema = fhirId();
@@ -127,6 +132,7 @@ describe("FHIR primitives", () => {
 			expect(fhirCode().safeParse(" ").success).toBe(false);
 			expect(fhirOid().safeParse("1.2.840.10008").success).toBe(false);
 			expect(fhirString().safeParse("").success).toBe(false);
+			expect(fhirString().safeParse("\v").success).toBe(false);
 			expect(
 				fhirUuid().safeParse("urn:uuid:123E4567-E89B-12D3-A456-426614174000")
 					.success,
@@ -137,6 +143,33 @@ describe("FHIR primitives", () => {
 			const payload = "Zm9v".repeat(200_000);
 
 			expect(fhirBase64Binary().safeParse(payload).success).toBe(true);
+		});
+	});
+
+	describe("fhirString empty-string configuration", () => {
+		it("rejects empty strings by default", () => {
+			expect(fhirString().safeParse("").success).toBe(false);
+		});
+
+		it("allows empty strings for newly constructed fhirString schemas after configuration", () => {
+			const strictSchema = fhirString();
+
+			configureFhirString({ allowEmpty: true });
+
+			expect(strictSchema.safeParse("").success).toBe(false);
+			expect(fhirString().safeParse("").success).toBe(true);
+		});
+
+		it("does not allow empty strings for other primitives", () => {
+			configureFhirString({ allowEmpty: true });
+
+			expect(fhirDate().safeParse("").success).toBe(false);
+		});
+
+		it("still rejects non-empty invalid fhirString values", () => {
+			configureFhirString({ allowEmpty: true });
+
+			expect(fhirString().safeParse("\v").success).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
# Summary

Adds an opt-in configuration API for accepting empty strings on only the FHIR `string` primitive while keeping strict non-empty behavior as the default.

## Changes

- Export `configureFhirString({ allowEmpty })` from `@fhir-zod/core`.
- Use a separate empty-allowing regex only when constructing new `fhirString()` schemas after configuration.
- Add focused primitive tests and document the configuration flow.

## API Or Breaking Changes

- [ ] No public API changes
- [x] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm test -- tests/fhir-primitives.test.ts
npm run typecheck
npx biome check src/shared/fhir-primitives.ts src/index.ts tests/fhir-primitives.test.ts
```

## Docs

- [ ] No docs update needed
- [x] Docs updated
