### PR TITLE
Add badges and Codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,13 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run coverage
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ success() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm ci
 
       - name: Fetch spec artifacts
-        run: npm run fetch-spec
+        run: npm run fetch-spec -- stu3 r4 r4b r5
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FHIR Zod
 
+[![CI](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml/badge.svg)](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/alysivji/fhir-zod/graph/badge.svg)](https://codecov.io/gh/alysivji/fhir-zod) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Code style: Biome](https://img.shields.io/badge/code%20style-biome-60a5fa)](https://biomejs.dev/)
+
 Canonical, versioned, generated TypeScript models and Zod schemas for the FHIR specification.
 
 ## Goal

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
 		],
 	},
 	test: {
+		coverage: {
+			reporter: ["text", "lcov"],
+		},
 		environment: "node",
 	},
 });


### PR DESCRIPTION
# Summary

Adds repository badges and wires CI coverage uploads to Codecov. CI now downloads all supported FHIR spec releases so spec-dependent tests run against STU3, R4, R4B, and R5 instead of only the default R4 cache.

## Changes

- Add CI, Codecov, MIT license, and Biome badges to the README.
- Configure Vitest to emit `lcov` coverage and upload it with `codecov/codecov-action@v5`.
- Fetch `stu3 r4 r4b r5` spec artifacts in CI so the existing `.local/spec-cache` cache covers every supported release.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run check
npm run coverage
npm run fetch-spec -- stu3 r4 r4b r5
npm test
```

## Docs

- [ ] No docs update needed
- [x] Docs updated
