### PR TITLE
Rename package and add FHIR README attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # FHIR Zod
 
+Canonical, versioned, generated TypeScript models and Zod schemas for the FHIR specification.
+
+![HL7 FHIR](https://img.shields.io/badge/HL7%20FHIR-compatible-blue)  ![FHIR STU3](https://img.shields.io/badge/FHIR-STU3-lightgrey) ![FHIR R4](https://img.shields.io/badge/FHIR-R4-green) ![FHIR R4B](https://img.shields.io/badge/FHIR-R4B-blue) ![FHIR R5](https://img.shields.io/badge/FHIR-R5-purple)
+
 [![CI](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml/badge.svg)](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/alysivji/fhir-zod/graph/badge.svg)](https://codecov.io/gh/alysivji/fhir-zod) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Code style: Biome](https://img.shields.io/badge/code%20style-biome-60a5fa)](https://biomejs.dev/)
 
-Canonical, versioned, generated TypeScript models and Zod schemas for the FHIR specification.
+## Standards Coverage
+
+FHIR STU3, R4, R4B, and R5 interfaces and Zod schemas are generated from the official FHIR specifications and tested against official FHIR examples.
 
 ## Goal
 
@@ -533,3 +539,7 @@ No manual edits to generated schemas.
 
 - https://zod.dev/library-authors
 - https://github.com/nazrulworld/fhir.resources
+
+## Trademark Notice
+
+FHIR® is a registered trademark of Health Level Seven International (HL7). Use of the FHIR® name does not imply endorsement by HL7.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Current repository status:
 ## Installation
 
 ```bash
-npm install @fhir-zod/core
+npm install fhir-zod
 ```
 
 Library consumers should install Zod as well:
@@ -55,8 +55,8 @@ npm install zod
 ## Usage
 
 ```ts
-import type { Patient } from "@fhir-zod/core/r4"
-import { PatientSchema } from "@fhir-zod/core/r4"
+import type { Patient } from "fhir-zod/r4"
+import { PatientSchema } from "fhir-zod/r4"
 
 const parsed = PatientSchema.parse(data)
 
@@ -72,7 +72,7 @@ payloads that use empty strings for the FHIR `string` primitive, configure the
 root package before constructing or importing schemas that use `fhirString()`:
 
 ```ts
-import { configureFhirString } from "@fhir-zod/core"
+import { configureFhirString } from "fhir-zod"
 
 configureFhirString({ allowEmpty: true })
 ```
@@ -329,8 +329,8 @@ PatientSchema.safeParse(data)
 FHIR versions are explicitly separated.
 
 ```ts
-import { Patient } from "@fhir-zod/core/r4"
-import { Patient as PatientR5 } from "@fhir-zod/core/r5"
+import { Patient } from "fhir-zod/r4"
+import { Patient as PatientR5 } from "fhir-zod/r5"
 ```
 
 Do NOT mix versions.

--- a/TASKS.md
+++ b/TASKS.md
@@ -16,12 +16,12 @@ Track the work needed to align the repository with the current README.
 
 ## Package Surface
 
-- [x] Publish root package as `@fhir-zod/core`
+- [x] Publish root package as `fhir-zod`
 - [x] Export versioned subpaths for `./stu3`
 - [x] Export versioned subpaths for `./r4`
 - [x] Export versioned subpaths for `./r4b`
 - [x] Export versioned subpaths for `./r5`
-- [x] Verify subpath import works for `@fhir-zod/core/r4`
+- [x] Verify subpath import works for `fhir-zod/r4`
 - [x] Emit package output in a tree-shakeable shape
   Current state:
   package builds use unbundled ESM output with `sideEffects: false`, and a
@@ -156,7 +156,7 @@ Track the work needed to align the repository with the current README.
 - [x] Add package tree-shaking regression test
   Current state:
   `tests/tree-shaking.test.ts` builds a temporary package and bundles a consumer
-  import of `PatientSchema` from `@fhir-zod/core/r4`, asserting unrelated R4
+  import of `PatientSchema` from `fhir-zod/r4`, asserting unrelated R4
   schema internals are absent from the consumer bundle.
 - [ ] Consider a dedicated CI profile that exercises spec-dependent suites after `npm run fetch-spec`
 - [ ] Investigate official example expected failures that violate emitted structural constraints

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@fhir-zod/core",
+	"name": "fhir-zod",
 	"version": "0.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@fhir-zod/core",
+			"name": "fhir-zod",
 			"version": "0.0.0",
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@fhir-zod/core",
+	"name": "fhir-zod",
 	"version": "0.0.0",
 	"private": true,
 	"license": "MIT",

--- a/tests/fhir-primitives.test.ts
+++ b/tests/fhir-primitives.test.ts
@@ -1,6 +1,6 @@
-import { configureFhirString } from "@fhir-zod/core";
-import * as r4Schemas from "@fhir-zod/core/r4";
-import * as r4bSchemas from "@fhir-zod/core/r4b";
+import { configureFhirString } from "fhir-zod";
+import * as r4Schemas from "fhir-zod/r4";
+import * as r4bSchemas from "fhir-zod/r4b";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	fhirBase64Binary,

--- a/tests/generated-types.test.ts
+++ b/tests/generated-types.test.ts
@@ -7,7 +7,7 @@ import type {
 	Patient,
 	Practitioner,
 	ValueSet,
-} from "@fhir-zod/core/r4";
+} from "fhir-zod/r4";
 import {
 	AccountSchema,
 	BundleSchema,
@@ -16,17 +16,14 @@ import {
 	PatientSchema,
 	PractitionerSchema,
 	ValueSetSchema,
-} from "@fhir-zod/core/r4";
-import type {
-	Patient as R4BPatient,
-	Timing as R4BTiming,
-} from "@fhir-zod/core/r4b";
+} from "fhir-zod/r4";
+import type { Patient as R4BPatient, Timing as R4BTiming } from "fhir-zod/r4b";
 import {
 	PatientSchema as R4BPatientSchema,
 	TimingSchema as R4BTimingSchema,
-} from "@fhir-zod/core/r4b";
-import type { Patient as STU3Patient } from "@fhir-zod/core/stu3";
-import { PatientSchema as STU3PatientSchema } from "@fhir-zod/core/stu3";
+} from "fhir-zod/r4b";
+import type { Patient as STU3Patient } from "fhir-zod/stu3";
+import { PatientSchema as STU3PatientSchema } from "fhir-zod/stu3";
 import { describe, expect, it } from "vitest";
 
 describe("generated model types", () => {

--- a/tests/patient.test.ts
+++ b/tests/patient.test.ts
@@ -1,4 +1,4 @@
-import { PatientSchema } from "@fhir-zod/core/r4";
+import { PatientSchema } from "fhir-zod/r4";
 import { describe, expect, it } from "vitest";
 
 describe("Patient", () => {

--- a/tests/primitive-array-json.test.ts
+++ b/tests/primitive-array-json.test.ts
@@ -1,4 +1,4 @@
-import { HumanNameSchema, TimingSchema } from "@fhir-zod/core/r4b";
+import { HumanNameSchema, TimingSchema } from "fhir-zod/r4b";
 import { describe, expect, it } from "vitest";
 
 describe("FHIR primitive array JSON representation", () => {

--- a/tests/r4-official-examples.test.ts
+++ b/tests/r4-official-examples.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import * as r4Schemas from "@fhir-zod/core/r4";
+import * as r4Schemas from "fhir-zod/r4";
 import { describeOfficialExamplesSuite } from "./helpers/official-examples-suite.ts";
 import { r4ExampleExpectedFailures } from "./r4-example-expected-failures.ts";
 

--- a/tests/r4b-official-examples.test.ts
+++ b/tests/r4b-official-examples.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import * as r4bSchemas from "@fhir-zod/core/r4b";
+import * as r4bSchemas from "fhir-zod/r4b";
 import { describeOfficialExamplesSuite } from "./helpers/official-examples-suite.ts";
 import { r4bExampleExpectedFailures } from "./r4b-example-expected-failures.ts";
 

--- a/tests/r5-official-examples.test.ts
+++ b/tests/r5-official-examples.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import * as r5Schemas from "@fhir-zod/core/r5";
+import * as r5Schemas from "fhir-zod/r5";
 import { describeOfficialExamplesSuite } from "./helpers/official-examples-suite.ts";
 import { r5ExampleExpectedFailures } from "./r5-example-expected-failures.ts";
 

--- a/tests/stu3-official-examples.test.ts
+++ b/tests/stu3-official-examples.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import * as stu3Schemas from "@fhir-zod/core/stu3";
+import * as stu3Schemas from "fhir-zod/stu3";
 import { describeOfficialExamplesSuite } from "./helpers/official-examples-suite.ts";
 import { stu3ExampleExpectedFailures } from "./stu3-example-expected-failures.ts";
 

--- a/tests/tree-shaking.test.ts
+++ b/tests/tree-shaking.test.ts
@@ -75,7 +75,7 @@ describe("package tree shaking", () => {
 				platform: "neutral",
 				stdin: {
 					contents: [
-						'import { PatientSchema } from "@fhir-zod/core/r4";',
+						'import { PatientSchema } from "fhir-zod/r4";',
 						"console.log(PatientSchema);",
 					].join("\n"),
 					loader: "js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,11 +18,11 @@
 		"verbatimModuleSyntax": true,
 		"baseUrl": ".",
 		"paths": {
-			"@fhir-zod/core": ["./src/index.ts"],
-			"@fhir-zod/core/r4": ["./src/r4/index.ts"],
-			"@fhir-zod/core/r4b": ["./src/r4b/index.ts"],
-			"@fhir-zod/core/r5": ["./src/r5/index.ts"],
-			"@fhir-zod/core/stu3": ["./src/stu3/index.ts"]
+			"fhir-zod": ["./src/index.ts"],
+			"fhir-zod/r4": ["./src/r4/index.ts"],
+			"fhir-zod/r4b": ["./src/r4b/index.ts"],
+			"fhir-zod/r5": ["./src/r5/index.ts"],
+			"fhir-zod/stu3": ["./src/stu3/index.ts"]
 		}
 	},
 	"include": ["src", "scripts", "tests", "tsdown.config.ts", "vitest.config.ts"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,31 +5,31 @@ export default defineConfig({
 	resolve: {
 		alias: [
 			{
-				find: "@fhir-zod/core/r4",
+				find: "fhir-zod/r4",
 				replacement: fileURLToPath(
 					new URL("./src/r4/index.ts", import.meta.url),
 				),
 			},
 			{
-				find: "@fhir-zod/core/r4b",
+				find: "fhir-zod/r4b",
 				replacement: fileURLToPath(
 					new URL("./src/r4b/index.ts", import.meta.url),
 				),
 			},
 			{
-				find: "@fhir-zod/core/r5",
+				find: "fhir-zod/r5",
 				replacement: fileURLToPath(
 					new URL("./src/r5/index.ts", import.meta.url),
 				),
 			},
 			{
-				find: "@fhir-zod/core/stu3",
+				find: "fhir-zod/stu3",
 				replacement: fileURLToPath(
 					new URL("./src/stu3/index.ts", import.meta.url),
 				),
 			},
 			{
-				find: /^@fhir-zod\/core$/,
+				find: /^fhir-zod$/,
 				replacement: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
 			},
 		],


### PR DESCRIPTION
## Summary
- rename the npm package from @fhir-zod/core to fhir-zod
- update package subpath imports, resolver aliases, tests, README examples, and task docs
- add text-based FHIR compatibility/version badges, standards coverage text, and FHIR trademark attribution

## Testing
- npm run check
- npm test
- commit hooks passed: end-of-file, trailing whitespace, Biome format, Biome check