### PR TITLE
Prepare package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Bring your own FHIR workflow. This package focuses on structural validation, not
 
 `fhir-zod` is pre-release. The package shape is stabilizing, and breaking changes are still possible before the first public release.
 
-This branch currently marks the package as private, so the install command below describes the intended public package shape once publishing is enabled.
+The install command below describes the intended public package shape. The project is still pre-release, so publication timing, versioning, and API details may change.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
 				"vitest": "^3.1.1",
 				"zod": "^3.25.0"
 			},
+			"engines": {
+				"node": ">=24"
+			},
 			"peerDependencies": {
 				"zod": "^3.25.0"
 			}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,29 @@
 {
 	"name": "fhir-zod",
 	"version": "0.0.0",
-	"private": true,
+	"description": "Generated TypeScript models and Zod schemas for HL7 FHIR.",
 	"license": "MIT",
 	"type": "module",
 	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/alysivji/fhir-zod"
+	},
+	"bugs": {
+		"url": "https://github.com/alysivji/fhir-zod/issues"
+	},
+	"homepage": "https://github.com/alysivji/fhir-zod#readme",
+	"keywords": [
+		"fhir",
+		"hl7",
+		"healthcare",
+		"typescript",
+		"zod",
+		"validation"
+	],
+	"engines": {
+		"node": ">=24"
+	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -31,7 +50,10 @@
 		}
 	},
 	"files": [
-		"dist"
+		"dist/**/*.d.ts",
+		"dist/**/*.js",
+		"LICENSE",
+		"README.md"
 	],
 	"scripts": {
 		"build": "npm run typecheck && tsdown",
@@ -49,6 +71,8 @@
 		"list:r4b-targets": "node scripts/list-r4b-targets.ts",
 		"list:r5-targets": "node scripts/list-r5-targets.ts",
 		"lint": "biome lint .",
+		"pack:check": "npm pack --dry-run",
+		"prepack": "npm run build",
 		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},


### PR DESCRIPTION
# Summary

Prepare `fhir-zod` package metadata for publishing and tighten the npm package contents to built schemas and type declarations. Closes #19.

## Changes

- Add package metadata for description, repository, bugs, homepage, keywords, and Node engine support.
- Restrict published files to `dist/**/*.js`, `dist/**/*.d.ts`, `README.md`, and `LICENSE`, with `prepack` and `pack:check` scripts for repeatable package inspection.
- Update the README pre-release note now that the package is no longer marked private.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run build
npm run check
npm test
npm pack --dry-run --ignore-scripts --json
```

`npm test` passed with 3052 tests passing and 70 spec-cache-dependent tests skipped.

## Docs

- [ ] No docs update needed
- [x] Docs updated
