### PR TITLE
Increase handwritten coverage for scripts and R4 schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Useful commands:
 npm test
 npm run typecheck
 npm run fetch-spec
+npm run fetch-spec:all
 npm run generate
 ```
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"coverage": "vitest run --coverage",
 		"fetch-examples": "node scripts/fetch-examples.ts",
 		"fetch-spec": "node scripts/fetch-spec.ts",
+		"fetch-spec:all": "node scripts/fetch-spec.ts all",
 		"format": "biome format --write .",
 		"generate": "node scripts/generate.ts",
 		"inspect:choice-groups": "node scripts/inspect-choice-groups.ts",

--- a/scripts/fetch-examples.ts
+++ b/scripts/fetch-examples.ts
@@ -7,52 +7,58 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+	type FhirRelease,
 	type FhirVersionId,
 	getFhirRelease,
 } from "../src/generator/versions.ts";
 
 type SupportedVersion = FhirVersionId;
 
-type ExampleLink = {
+export type ExampleLink = {
 	filename: string;
 	id: string;
 	url: string;
 };
 
+export type FetchExamplesOptions = {
+	delayMs: number;
+	forceRefresh: boolean;
+	limit: number | null;
+	requestedResources: string[];
+	version: SupportedVersion;
+};
+
+export type FetchExamplesDependencies = {
+	execFileSync: typeof execFileSync;
+	existsSync: typeof existsSync;
+	getRelease: (version: string) => FhirRelease | null;
+	log: (message: string) => void;
+	mkdirSync: typeof mkdirSync;
+	readdirSync: typeof readdirSync;
+	rmSync: typeof rmSync;
+	warn: (message: string) => void;
+	writeFileSync: typeof writeFileSync;
+};
+
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
-const args = process.argv.slice(2);
-const positionalArgs = collectPositionalArgs(args);
-const requestedVersion = parseVersion(positionalArgs[0]);
-const version: SupportedVersion = requestedVersion ?? "r4";
-const selectedRelease = getFhirRelease(version);
-
-if (!selectedRelease) {
-	throw new Error(`Unknown FHIR version "${version}".`);
-}
-
-const release = selectedRelease;
-
-const resourceArgs = requestedVersion
-	? positionalArgs.slice(1)
-	: positionalArgs;
-const fixturesRoot = join(repoRoot, "tests", "fixtures", version);
-const knownResourceNames = release.listCoreResourceNames();
-const forceRefresh = hasFlag("--force");
-const delayMs = parseNumberFlag("--delay-ms") ?? 1000;
-const limit = parseNumberFlag("--limit");
-const requestedResources = selectResourceNames(resourceArgs);
 const fetchMaxBufferBytes = 64 * 1024 * 1024;
 
-let requestCount = 0;
+const defaultDependencies: FetchExamplesDependencies = {
+	execFileSync,
+	existsSync,
+	getRelease: getFhirRelease,
+	log: console.log,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	warn: console.warn,
+	writeFileSync,
+};
 
-function parseVersion(value: string | undefined): SupportedVersion | null {
-	return value && getFhirRelease(value) ? (value as SupportedVersion) : null;
-}
-
-function parseFlag(name: string): string | null {
+export function parseFlag(args: string[], name: string): string | null {
 	const directMatch = args.find((arg) => arg.startsWith(`${name}=`));
 
 	if (directMatch) {
@@ -68,8 +74,8 @@ function parseFlag(name: string): string | null {
 	return args[flagIndex + 1] ?? null;
 }
 
-function parseNumberFlag(name: string): number | null {
-	const raw = parseFlag(name);
+export function parseNumberFlag(args: string[], name: string): number | null {
+	const raw = parseFlag(args, name);
 
 	if (raw === null) {
 		return null;
@@ -86,11 +92,11 @@ function parseNumberFlag(name: string): number | null {
 	return value;
 }
 
-function hasFlag(name: string): boolean {
+function hasFlag(args: string[], name: string): boolean {
 	return args.includes(name);
 }
 
-function collectPositionalArgs(argv: string[]): string[] {
+export function collectPositionalArgs(argv: string[]): string[] {
 	const positional: string[] = [];
 	const flagsWithValues = new Set(["--delay-ms", "--limit"]);
 
@@ -113,7 +119,40 @@ function collectPositionalArgs(argv: string[]): string[] {
 	return positional;
 }
 
-function sleep(milliseconds: number): void {
+export function parseFetchExamplesOptions(
+	argv: string[],
+	deps: Pick<FetchExamplesDependencies, "getRelease"> = defaultDependencies,
+): FetchExamplesOptions {
+	const positionalArgs = collectPositionalArgs(argv);
+	const requestedVersion =
+		positionalArgs[0] && deps.getRelease(positionalArgs[0])
+			? (positionalArgs[0] as SupportedVersion)
+			: null;
+	const version: SupportedVersion = requestedVersion ?? "r4";
+	const release = deps.getRelease(version);
+
+	if (!release) {
+		throw new Error(`Unknown FHIR version "${version}".`);
+	}
+
+	const resourceArgs = requestedVersion
+		? positionalArgs.slice(1)
+		: positionalArgs;
+
+	return {
+		delayMs: parseNumberFlag(argv, "--delay-ms") ?? 1000,
+		forceRefresh: hasFlag(argv, "--force"),
+		limit: parseNumberFlag(argv, "--limit"),
+		requestedResources: selectResourceNames(
+			resourceArgs,
+			release.listCoreResourceNames(),
+			version,
+		),
+		version,
+	};
+}
+
+export function sleep(milliseconds: number): void {
 	if (milliseconds <= 0) {
 		return;
 	}
@@ -121,25 +160,31 @@ function sleep(milliseconds: number): void {
 	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
-function fetchText(url: string): string {
-	if (requestCount > 0) {
-		sleep(delayMs);
+function fetchText(
+	url: string,
+	context: {
+		deps: FetchExamplesDependencies;
+		delayMs: number;
+		repoRoot: string;
+		requestCount: number;
+	},
+): string {
+	if (context.requestCount > 0) {
+		sleep(context.delayMs);
 	}
 
-	requestCount += 1;
-
-	return execFileSync("curl", ["-L", "-sS", url], {
-		cwd: repoRoot,
+	return context.deps.execFileSync("curl", ["-L", "-sS", url], {
+		cwd: context.repoRoot,
 		encoding: "utf8",
 		maxBuffer: fetchMaxBufferBytes,
 	});
 }
 
-function normalizeTextFileContent(content: string): string {
+export function normalizeTextFileContent(content: string): string {
 	return content.replace(/\r\n/g, "\n").replace(/\n*$/, "\n");
 }
 
-function decodeHtmlEntities(value: string): string {
+export function decodeHtmlEntities(value: string): string {
 	return value
 		.replaceAll("&amp;", "&")
 		.replaceAll("&quot;", '"')
@@ -148,15 +193,19 @@ function decodeHtmlEntities(value: string): string {
 		.replaceAll("&gt;", ">");
 }
 
-function resourceExamplesPageUrl(resourceName: string): string {
+function resourceExamplesPageUrl(
+	release: FhirRelease,
+	resourceName: string,
+): string {
 	return release.exampleResourcePageUrl(resourceName);
 }
 
-function discoverJsonExamples(
+export function discoverJsonExamples(
+	release: FhirRelease,
 	resourceName: string,
 	pageHtml: string,
 ): ExampleLink[] {
-	const pageUrl = resourceExamplesPageUrl(resourceName);
+	const pageUrl = resourceExamplesPageUrl(release, resourceName);
 	const resourceSlug = resourceName.toLowerCase();
 	const discovered = new Map<string, ExampleLink>();
 	const linkPattern = new RegExp(
@@ -194,7 +243,11 @@ function discoverJsonExamples(
 	);
 }
 
-function selectResourceNames(requested: string[]): string[] {
+export function selectResourceNames(
+	requested: string[],
+	knownResourceNames: string[],
+	version: SupportedVersion,
+): string[] {
 	if (requested.length === 0) {
 		return knownResourceNames;
 	}
@@ -219,26 +272,37 @@ function selectResourceNames(requested: string[]): string[] {
 	});
 }
 
-function clearFixtureDirectory(resourceName: string): string {
+function clearFixtureDirectory(
+	resourceName: string,
+	fixturesRoot: string,
+	deps: FetchExamplesDependencies,
+): string {
 	const outputDir = join(fixturesRoot, resourceName);
 
-	rmSync(outputDir, { force: true, recursive: true });
-	mkdirSync(outputDir, { recursive: true });
+	deps.rmSync(outputDir, { force: true, recursive: true });
+	deps.mkdirSync(outputDir, { recursive: true });
 
 	return outputDir;
 }
 
-function hasFetchedFixtures(resourceName: string): boolean {
+function hasFetchedFixtures(
+	resourceName: string,
+	fixturesRoot: string,
+	deps: FetchExamplesDependencies,
+): boolean {
 	const outputDir = join(fixturesRoot, resourceName);
 
-	if (!existsSync(outputDir)) {
+	if (!deps.existsSync(outputDir)) {
 		return false;
 	}
 
-	return readdirSync(outputDir).some((entry) => entry.endsWith(".json"));
+	return deps.readdirSync(outputDir).some((entry) => entry.endsWith(".json"));
 }
 
-function assertNotHumanVerification(pageHtml: string, pageUrl: string): void {
+export function assertNotHumanVerification(
+	pageHtml: string,
+	pageUrl: string,
+): void {
 	if (
 		pageHtml.includes("<title>Human Verification</title>") ||
 		pageHtml.includes('id="captcha-container"')
@@ -249,55 +313,117 @@ function assertNotHumanVerification(pageHtml: string, pageUrl: string): void {
 	}
 }
 
-function fetchResourceExamples(resourceName: string): boolean {
-	const pageUrl = resourceExamplesPageUrl(resourceName);
-	const pageHtml = fetchText(pageUrl);
+function fetchResourceExamples(
+	resourceName: string,
+	context: {
+		deps: FetchExamplesDependencies;
+		fixturesRoot: string;
+		release: FhirRelease;
+		repoRoot: string;
+		requestCount: number;
+		version: SupportedVersion;
+		delayMs: number;
+	},
+): { fetched: boolean; requestCount: number } {
+	const pageUrl = resourceExamplesPageUrl(context.release, resourceName);
+	const pageHtml = fetchText(pageUrl, context);
+	let requestCount = context.requestCount + 1;
 
 	assertNotHumanVerification(pageHtml, pageUrl);
-	const discoveredExamples = discoverJsonExamples(resourceName, pageHtml);
+	const discoveredExamples = discoverJsonExamples(
+		context.release,
+		resourceName,
+		pageHtml,
+	);
 
 	if (discoveredExamples.length === 0) {
-		console.warn(
-			`No JSON examples discovered for ${version.toUpperCase()} ${resourceName} on ${pageUrl}; leaving fixtures unchanged.`,
+		context.deps.warn(
+			`No JSON examples discovered for ${context.version.toUpperCase()} ${resourceName} on ${pageUrl}; leaving fixtures unchanged.`,
 		);
-		return false;
+		return { fetched: false, requestCount };
 	}
 
-	const outputDir = clearFixtureDirectory(resourceName);
+	const outputDir = clearFixtureDirectory(
+		resourceName,
+		context.fixturesRoot,
+		context.deps,
+	);
 
 	for (const example of discoveredExamples) {
-		const json = fetchText(example.url);
+		const json = fetchText(example.url, {
+			...context,
+			requestCount,
+		});
+		requestCount += 1;
 		const outputPath = join(outputDir, example.filename);
 
-		writeFileSync(outputPath, normalizeTextFileContent(json), "utf8");
-		console.log(
-			`Fetched ${version.toUpperCase()} ${resourceName} example ${example.id} -> ${outputPath}`,
+		context.deps.writeFileSync(
+			outputPath,
+			normalizeTextFileContent(json),
+			"utf8",
+		);
+		context.deps.log(
+			`Fetched ${context.version.toUpperCase()} ${resourceName} example ${example.id} -> ${outputPath}`,
 		);
 	}
 
-	return true;
+	return { fetched: true, requestCount };
 }
 
-function main(): void {
-	mkdirSync(fixturesRoot, { recursive: true });
+export function runFetchExamplesCli(
+	argv = process.argv.slice(2),
+	options: {
+		deps?: Partial<FetchExamplesDependencies>;
+		repoRoot?: string;
+	} = {},
+): void {
+	const deps = { ...defaultDependencies, ...options.deps };
+	const root = options.repoRoot ?? repoRoot;
+	const parsedOptions = parseFetchExamplesOptions(argv, deps);
+	const release = deps.getRelease(parsedOptions.version);
+
+	if (!release) {
+		throw new Error(`Unknown FHIR version "${parsedOptions.version}".`);
+	}
+
+	const fixturesRoot = join(root, "tests", "fixtures", parsedOptions.version);
+	let requestCount = 0;
+
+	deps.mkdirSync(fixturesRoot, { recursive: true });
 	const failures: string[] = [];
 	const skipped: string[] = [];
 	const fetched: string[] = [];
 	const noExamples: string[] = [];
 	const selectedResources =
-		limit === null ? requestedResources : requestedResources.slice(0, limit);
+		parsedOptions.limit === null
+			? parsedOptions.requestedResources
+			: parsedOptions.requestedResources.slice(0, parsedOptions.limit);
 
 	for (const resourceName of selectedResources) {
-		if (!forceRefresh && hasFetchedFixtures(resourceName)) {
+		if (
+			!parsedOptions.forceRefresh &&
+			hasFetchedFixtures(resourceName, fixturesRoot, deps)
+		) {
 			skipped.push(resourceName);
-			console.log(
-				`Skipping ${version.toUpperCase()} ${resourceName}; fixtures already exist.`,
+			deps.log(
+				`Skipping ${parsedOptions.version.toUpperCase()} ${resourceName}; fixtures already exist.`,
 			);
 			continue;
 		}
 
 		try {
-			if (fetchResourceExamples(resourceName)) {
+			const result = fetchResourceExamples(resourceName, {
+				delayMs: parsedOptions.delayMs,
+				deps,
+				fixturesRoot,
+				release,
+				repoRoot: root,
+				requestCount,
+				version: parsedOptions.version,
+			});
+			requestCount = result.requestCount;
+
+			if (result.fetched) {
 				fetched.push(resourceName);
 			} else {
 				noExamples.push(resourceName);
@@ -313,10 +439,10 @@ function main(): void {
 					selectedResources.indexOf(resourceName),
 				);
 
-				console.warn(
-					`Stopped at ${version.toUpperCase()} ${resourceName}; ${detail}\nFetched ${fetched.length} resources this run, skipped ${skipped.length}. Resume later with:\n` +
-						`npm run fetch-examples -- ${version} ${remainingResources
-							.slice(0, limit ?? remainingResources.length)
+				deps.warn(
+					`Stopped at ${parsedOptions.version.toUpperCase()} ${resourceName}; ${detail}\nFetched ${fetched.length} resources this run, skipped ${skipped.length}. Resume later with:\n` +
+						`npm run fetch-examples -- ${parsedOptions.version} ${remainingResources
+							.slice(0, parsedOptions.limit ?? remainingResources.length)
 							.join(" ")}`,
 				);
 				break;
@@ -328,13 +454,18 @@ function main(): void {
 
 	if (failures.length > 0) {
 		throw new Error(
-			`Unable to fetch fixtures for ${failures.length} ${version.toUpperCase()} resources.\n${failures.join("\n")}`,
+			`Unable to fetch fixtures for ${failures.length} ${parsedOptions.version.toUpperCase()} resources.\n${failures.join("\n")}`,
 		);
 	}
 
-	console.log(
-		`Finished ${version.toUpperCase()} example fetch. fetched=${fetched.length} skipped=${skipped.length} noExamples=${noExamples.length} requests=${requestCount}`,
+	deps.log(
+		`Finished ${parsedOptions.version.toUpperCase()} example fetch. fetched=${fetched.length} skipped=${skipped.length} noExamples=${noExamples.length} requests=${requestCount}`,
 	);
 }
 
-main();
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	runFetchExamplesCli();
+}

--- a/scripts/fetch-spec.ts
+++ b/scripts/fetch-spec.ts
@@ -24,6 +24,7 @@ export type SpecManifest = {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
+const allVersionsSelector = "all";
 const defaultVersions = new Set(["r4"]);
 
 export type FetchSpecDependencies = {
@@ -59,10 +60,12 @@ export function loadManifests(
 	const root = options.repoRoot ?? repoRoot;
 	const specRoot = join(root, "src", "spec");
 	const requestedVersions = new Set(options.requestedVersions ?? []);
+	const includeAllVersions = requestedVersions.has(allVersionsSelector);
 
 	return deps
 		.readdirSync(specRoot, { withFileTypes: true })
 		.filter((entry: Dirent) => entry.isDirectory())
+		.sort((left, right) => left.name.localeCompare(right.name))
 		.map((entry) => ({
 			version: entry.name,
 			manifestPath: join(specRoot, entry.name, "manifest.json"),
@@ -70,6 +73,10 @@ export function loadManifests(
 		.filter(({ manifestPath, version }) => {
 			if (!deps.existsSync(manifestPath)) {
 				return false;
+			}
+
+			if (includeAllVersions) {
+				return true;
 			}
 
 			if (requestedVersions.size === 0) {

--- a/scripts/fetch-spec.ts
+++ b/scripts/fetch-spec.ts
@@ -8,9 +8,9 @@ import {
 	rmSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-type SpecManifest = {
+export type SpecManifest = {
 	fhirVersion: string;
 	jsonSchemaArchiveEntry?: string;
 	jsonSchemaOutputPath?: string;
@@ -24,23 +24,51 @@ type SpecManifest = {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
-const specRoot = join(repoRoot, "src", "spec");
-const requestedVersions = new Set(process.argv.slice(2));
 const defaultVersions = new Set(["r4"]);
 
-function loadManifests(): Array<{
+export type FetchSpecDependencies = {
+	execFileSync: typeof execFileSync;
+	existsSync: typeof existsSync;
+	mkdirSync: typeof mkdirSync;
+	readdirSync: typeof readdirSync;
+	readFileSync: typeof readFileSync;
+	rmSync: typeof rmSync;
+};
+
+const defaultDependencies: FetchSpecDependencies = {
+	execFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+};
+
+export function loadManifests(
+	options: {
+		deps?: FetchSpecDependencies;
+		repoRoot?: string;
+		requestedVersions?: Iterable<string>;
+	} = {},
+): Array<{
 	version: string;
 	manifestPath: string;
 	manifest: SpecManifest;
 }> {
-	return readdirSync(specRoot, { withFileTypes: true })
+	const deps = options.deps ?? defaultDependencies;
+	const root = options.repoRoot ?? repoRoot;
+	const specRoot = join(root, "src", "spec");
+	const requestedVersions = new Set(options.requestedVersions ?? []);
+
+	return deps
+		.readdirSync(specRoot, { withFileTypes: true })
 		.filter((entry: Dirent) => entry.isDirectory())
 		.map((entry) => ({
 			version: entry.name,
 			manifestPath: join(specRoot, entry.name, "manifest.json"),
 		}))
 		.filter(({ manifestPath, version }) => {
-			if (!existsSync(manifestPath)) {
+			if (!deps.existsSync(manifestPath)) {
 				return false;
 			}
 
@@ -61,42 +89,51 @@ function loadManifests(): Array<{
 				version,
 				manifestPath,
 				manifest: JSON.parse(
-					readFileSync(manifestPath, "utf8"),
+					deps.readFileSync(manifestPath, "utf8"),
 				) as SpecManifest,
 			}),
 		);
 }
 
-function ensurePackage(
+export function ensurePackage(
 	version: string,
 	manifestPath: string,
 	manifest: SpecManifest,
+	options: {
+		deps?: FetchSpecDependencies;
+		repoRoot?: string;
+	} = {},
 ): void {
-	const packageDir = resolve(repoRoot, manifest.packageRoot);
+	const deps = options.deps ?? defaultDependencies;
+	const root = options.repoRoot ?? repoRoot;
+	const packageDir = resolve(root, manifest.packageRoot);
 	const packageParentDir = dirname(packageDir);
-	const downloadDir = join(repoRoot, ".local", "spec-cache", "downloads");
+	const downloadDir = join(root, ".local", "spec-cache", "downloads");
 	const archivePath = join(
 		downloadDir,
 		`${manifest.packageName}-${manifest.packageVersion}.tgz`,
 	);
-	const packageReady = isPackageReady(packageDir, manifest);
+	const packageReady = isPackageReady(packageDir, manifest, {
+		deps,
+		repoRoot: root,
+	});
 
-	mkdirSync(downloadDir, { recursive: true });
-	mkdirSync(packageParentDir, { recursive: true });
+	deps.mkdirSync(downloadDir, { recursive: true });
+	deps.mkdirSync(packageParentDir, { recursive: true });
 
 	if (!packageReady) {
 		console.log(
 			`spec-fetch[${version}]: cache miss for extracted package, downloading ${manifest.packageName}@${manifest.packageVersion}.`,
 		);
-		rmSync(packageDir, { recursive: true, force: true });
+		deps.rmSync(packageDir, { recursive: true, force: true });
 
-		execFileSync("curl", ["-L", manifest.sourceUrl, "-o", archivePath], {
-			cwd: repoRoot,
+		deps.execFileSync("curl", ["-L", manifest.sourceUrl, "-o", archivePath], {
+			cwd: root,
 			stdio: "inherit",
 		});
 
-		execFileSync("tar", ["-xzf", archivePath, "-C", packageParentDir], {
-			cwd: repoRoot,
+		deps.execFileSync("tar", ["-xzf", archivePath, "-C", packageParentDir], {
+			cwd: root,
 			stdio: "inherit",
 		});
 	} else {
@@ -105,15 +142,25 @@ function ensurePackage(
 		);
 	}
 
-	ensureJsonSchema(downloadDir, manifest);
+	ensureJsonSchema(downloadDir, manifest, { deps, repoRoot: root });
 
 	console.log(
 		`Fetched ${version}: ${manifest.packageName}@${manifest.packageVersion} for ${manifest.fhirVersion} using ${manifestPath}.`,
 	);
 }
 
-function isPackageReady(packageDir: string, manifest: SpecManifest): boolean {
-	if (!existsSync(packageDir)) {
+export function isPackageReady(
+	packageDir: string,
+	manifest: SpecManifest,
+	options: {
+		deps?: Pick<FetchSpecDependencies, "existsSync">;
+		repoRoot?: string;
+	} = {},
+): boolean {
+	const deps = options.deps ?? defaultDependencies;
+	const root = options.repoRoot ?? repoRoot;
+
+	if (!deps.existsSync(packageDir)) {
 		return false;
 	}
 
@@ -122,14 +169,14 @@ function isPackageReady(packageDir: string, manifest: SpecManifest): boolean {
 		"StructureDefinition-Patient.json",
 	);
 
-	if (!existsSync(structureDefinitionPath)) {
+	if (!deps.existsSync(structureDefinitionPath)) {
 		return false;
 	}
 
 	if (manifest.jsonSchemaOutputPath) {
-		const jsonSchemaPath = resolve(repoRoot, manifest.jsonSchemaOutputPath);
+		const jsonSchemaPath = resolve(root, manifest.jsonSchemaOutputPath);
 
-		if (!existsSync(jsonSchemaPath)) {
+		if (!deps.existsSync(jsonSchemaPath)) {
 			return false;
 		}
 	}
@@ -137,7 +184,14 @@ function isPackageReady(packageDir: string, manifest: SpecManifest): boolean {
 	return true;
 }
 
-function ensureJsonSchema(downloadDir: string, manifest: SpecManifest): void {
+export function ensureJsonSchema(
+	downloadDir: string,
+	manifest: SpecManifest,
+	options: {
+		deps?: FetchSpecDependencies;
+		repoRoot?: string;
+	} = {},
+): void {
 	if (
 		!manifest.jsonSchemaSourceUrl ||
 		!manifest.jsonSchemaArchiveEntry ||
@@ -146,9 +200,11 @@ function ensureJsonSchema(downloadDir: string, manifest: SpecManifest): void {
 		return;
 	}
 
-	const outputPath = resolve(repoRoot, manifest.jsonSchemaOutputPath);
+	const deps = options.deps ?? defaultDependencies;
+	const root = options.repoRoot ?? repoRoot;
+	const outputPath = resolve(root, manifest.jsonSchemaOutputPath);
 
-	if (existsSync(outputPath)) {
+	if (deps.existsSync(outputPath)) {
 		console.log(
 			`spec-fetch: using cached JSON schema at ${manifest.jsonSchemaOutputPath}.`,
 		);
@@ -164,17 +220,17 @@ function ensureJsonSchema(downloadDir: string, manifest: SpecManifest): void {
 		`spec-fetch: downloading JSON schema from ${manifest.jsonSchemaSourceUrl}.`,
 	);
 
-	execFileSync(
+	deps.execFileSync(
 		"curl",
 		["-L", manifest.jsonSchemaSourceUrl, "-o", archivePath],
 		{
-			cwd: repoRoot,
+			cwd: root,
 			stdio: "inherit",
 		},
 	);
 
-	mkdirSync(dirname(outputPath), { recursive: true });
-	execFileSync(
+	deps.mkdirSync(dirname(outputPath), { recursive: true });
+	deps.execFileSync(
 		"sh",
 		[
 			"-c",
@@ -185,16 +241,38 @@ function ensureJsonSchema(downloadDir: string, manifest: SpecManifest): void {
 			outputPath,
 		],
 		{
-			cwd: repoRoot,
+			cwd: root,
 			stdio: "inherit",
 		},
 	);
 }
 
-function basenameFromUrl(url: string): string {
+export function basenameFromUrl(url: string): string {
 	return url.split("/").at(-1) ?? "download";
 }
 
-for (const { version, manifestPath, manifest } of loadManifests()) {
-	ensurePackage(version, manifestPath, manifest);
+export function runFetchSpecCli(
+	argv = process.argv.slice(2),
+	options: {
+		deps?: FetchSpecDependencies;
+		repoRoot?: string;
+	} = {},
+): void {
+	const deps = options.deps ?? defaultDependencies;
+	const root = options.repoRoot ?? repoRoot;
+
+	for (const { version, manifestPath, manifest } of loadManifests({
+		deps,
+		repoRoot: root,
+		requestedVersions: argv,
+	})) {
+		ensurePackage(version, manifestPath, manifest, { deps, repoRoot: root });
+	}
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	runFetchSpecCli();
 }

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,23 +1,41 @@
+import { pathToFileURL } from "node:url";
 import {
+	type FhirRelease,
 	getFhirRelease,
 	supportedFhirVersions,
 } from "../src/generator/versions.ts";
 
-const requestedVersions = process.argv.slice(2);
-const versions = requestedVersions.length > 0 ? requestedVersions : ["r4"];
+export function runGenerateCli(
+	argv = process.argv.slice(2),
+	options: {
+		getRelease?: (version: string) => FhirRelease | null;
+		log?: (message: string) => void;
+	} = {},
+): void {
+	const getRelease = options.getRelease ?? getFhirRelease;
+	const log = options.log ?? console.log;
+	const versions = argv.length > 0 ? argv : ["r4"];
 
-for (const version of versions) {
-	const release = getFhirRelease(version);
+	for (const version of versions) {
+		const release = getRelease(version);
 
-	if (!release) {
-		throw new Error(
-			`Unknown generation target "${version}". Supported versions: ${supportedFhirVersions.join(", ")}.`,
-		);
+		if (!release) {
+			throw new Error(
+				`Unknown generation target "${version}". Supported versions: ${supportedFhirVersions.join(", ")}.`,
+			);
+		}
+
+		const result = release.generate();
+
+		for (const file of result.files) {
+			log(`generated ${file}`);
+		}
 	}
+}
 
-	const result = release.generate();
-
-	for (const file of result.files) {
-		console.log(`generated ${file}`);
-	}
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	runGenerateCli();
 }

--- a/scripts/list-targets.ts
+++ b/scripts/list-targets.ts
@@ -1,5 +1,9 @@
 import { pathToFileURL } from "node:url";
-import type { FhirVersionId, TargetEntry } from "../src/generator/versions.ts";
+import type {
+	FhirRelease,
+	FhirVersionId,
+	TargetEntry,
+} from "../src/generator/versions.ts";
 import {
 	getFhirRelease,
 	supportedFhirVersions,
@@ -23,14 +27,24 @@ const categoryFilters = new Set<string>([
 	"profile-resource",
 ]);
 
-export function runListTargetsCli(defaultVersion?: FhirVersionId): void {
-	const args = process.argv.slice(2);
+export function runListTargetsCli(
+	defaultVersion?: FhirVersionId,
+	options: {
+		argv?: string[];
+		getRelease?: (version: string) => FhirRelease | null;
+		log?: (message: string) => void;
+	} = {},
+): void {
+	const args = options.argv ?? process.argv.slice(2);
+	const getRelease = options.getRelease ?? getFhirRelease;
+	const log = options.log ?? console.log;
 	const positionalArgs = collectPositionalArgs(args);
 	const firstArgVersion = positionalArgs[0]
-		? getFhirRelease(positionalArgs[0])
+		? getRelease(positionalArgs[0])
 		: null;
-	const version = firstArgVersion?.id ?? defaultVersion ?? "r4";
-	const release = getFhirRelease(version);
+	const version =
+		firstArgVersion?.id ?? positionalArgs[0] ?? defaultVersion ?? "r4";
+	const release = getRelease(version);
 
 	if (!release) {
 		throw new Error(
@@ -75,7 +89,7 @@ export function runListTargetsCli(defaultVersion?: FhirVersionId): void {
 	const filteredNames = filteredEntries.map((entry) => entry.name);
 
 	if (outputMode === "summary") {
-		console.log(
+		log(
 			JSON.stringify(
 				{
 					categoryFilter,
@@ -92,11 +106,11 @@ export function runListTargetsCli(defaultVersion?: FhirVersionId): void {
 	}
 
 	if (outputMode === "names") {
-		console.log(filteredNames.join("\n"));
+		log(filteredNames.join("\n"));
 		return;
 	}
 
-	console.log(
+	log(
 		JSON.stringify(
 			{
 				categoryFilter,

--- a/tests/generator-model.test.ts
+++ b/tests/generator-model.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+	choiceSuffixForType,
+	definitionNameToFhirPath,
+	fhirPathToDefinitionName,
+	inferChoiceMetadata,
+	isPrimitiveType,
+	type NormalizedDefinition,
+	type NormalizedProperty,
+	normalizeDefinitionName,
+	normalizeTargetProfiles,
+	normalizeValue,
+	pascalCase,
+	primitiveRuntimeKind,
+	schemaExportName,
+	schemaInternalName,
+	sortDefinitions,
+	sortProperties,
+	uncapitalize,
+} from "../src/generator/model.ts";
+
+function property(jsonName: string): NormalizedProperty {
+	return {
+		binding: null,
+		choiceGroup: null,
+		choiceVariant: null,
+		description: null,
+		enumValues: null,
+		fhirPath: `Patient.${jsonName}`,
+		invariants: [],
+		isArray: false,
+		jsonName,
+		max: "1",
+		min: 0,
+		primitiveType: null,
+		required: false,
+		targetProfiles: [],
+		typeRef: "string",
+	};
+}
+
+function definition(name: string): NormalizedDefinition {
+	return {
+		baseName: null,
+		description: null,
+		kind: "resource",
+		name,
+		notes: [],
+		properties: [],
+		resourceTypeLiteral: name,
+		sourceMetadata: {
+			profileUrl: null,
+			releaseLabel: null,
+			version: null,
+		},
+	};
+}
+
+describe("generator model helpers", () => {
+	it("sorts definitions and primitive companion properties deterministically", () => {
+		expect(
+			sortDefinitions([definition("Patient"), definition("Account")]),
+		).toEqual([definition("Account"), definition("Patient")]);
+
+		expect(
+			sortProperties([
+				property("_profile"),
+				property("status"),
+				property("profile"),
+				property("_alias"),
+				property("alias"),
+			]).map((item) => item.jsonName),
+		).toEqual(["alias", "_alias", "profile", "_profile", "status"]);
+	});
+
+	it("classifies primitive types and runtime kinds", () => {
+		expect(isPrimitiveType("boolean")).toBe(true);
+		expect(isPrimitiveType("Reference")).toBe(false);
+		expect(isPrimitiveType(null)).toBe(false);
+		expect(primitiveRuntimeKind("boolean")).toBe("boolean");
+		expect(primitiveRuntimeKind("integer64")).toBe("string");
+		expect(primitiveRuntimeKind("decimal")).toBe("number");
+		expect(primitiveRuntimeKind("Reference")).toBeNull();
+	});
+
+	it("infers choice metadata for primitive suffixes and ignores underscore companions", () => {
+		expect(
+			inferChoiceMetadata("valueDateTime", ["valueString", "status"]),
+		).toEqual({
+			choiceGroup: "value[x]",
+			choiceVariant: "dateTime",
+		});
+		expect(inferChoiceMetadata("_valueDateTime", ["valueString"])).toBeNull();
+		expect(inferChoiceMetadata("valueUnknown", ["valueString"])).toBeNull();
+		expect(inferChoiceMetadata("valueString", ["status"])).toBeNull();
+	});
+
+	it("normalizes names, paths, profiles, and simple casing", () => {
+		expect(choiceSuffixForType("dateTime")).toBe("DateTime");
+		expect(choiceSuffixForType("custom-type")).toBe("Custom-type");
+		expect(definitionNameToFhirPath("Patient_Contact_Address")).toBe(
+			"Patient.contact.address",
+		);
+		expect(fhirPathToDefinitionName("Observation.value[x]")).toBe(
+			"Observation_Value",
+		);
+		expect(normalizeDefinitionName("Patient.schema.json")).toBe("Patient");
+		expect(schemaExportName("Patient")).toBe("PatientSchema");
+		expect(schemaInternalName("Patient")).toBe("PatientSchemaInternal");
+		expect(normalizeTargetProfiles(undefined)).toEqual([]);
+		expect(normalizeTargetProfiles("Patient")).toEqual(["Patient"]);
+		expect(normalizeTargetProfiles(["Observation", "Patient"])).toEqual([
+			"Observation",
+			"Patient",
+		]);
+		expect(normalizeValue(undefined)).toBeNull();
+		expect(normalizeValue("x")).toBe("x");
+		expect(pascalCase("patient")).toBe("Patient");
+		expect(uncapitalize("Patient")).toBe("patient");
+	});
+});

--- a/tests/generator-versions.test.ts
+++ b/tests/generator-versions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+	getFhirRelease,
+	R4BRelease,
+	R4Release,
+	R5Release,
+	STU3Release,
+	type TargetEntry,
+} from "../src/generator/versions.ts";
+
+const syntheticEntries: TargetEntry[] = [
+	{
+		abstract: true,
+		baseDefinition: null,
+		category: "abstract-whitelist",
+		kind: "complex-type",
+		name: "Element",
+		shouldGenerate: true,
+		type: "Element",
+		url: null,
+	},
+	{
+		abstract: false,
+		baseDefinition: "http://hl7.org/fhir/StructureDefinition/DomainResource",
+		category: "core-resource",
+		kind: "resource",
+		name: "Patient",
+		shouldGenerate: true,
+		type: "Patient",
+		url: null,
+	},
+	{
+		abstract: false,
+		baseDefinition: "http://example.test/Profile",
+		category: "profile-resource",
+		kind: "resource",
+		name: "CustomPatient",
+		shouldGenerate: false,
+		type: "Patient",
+		url: null,
+	},
+	{
+		abstract: false,
+		baseDefinition: null,
+		category: "other",
+		kind: "complex-type",
+		name: "Address",
+		shouldGenerate: false,
+		type: "Address",
+		url: null,
+	},
+];
+
+describe("FHIR version registry", () => {
+	it("returns all supported releases and null for unknown versions", () => {
+		expect(getFhirRelease("stu3")).toBeInstanceOf(STU3Release);
+		expect(getFhirRelease("r4")).toBeInstanceOf(R4Release);
+		expect(getFhirRelease("r4b")).toBeInstanceOf(R4BRelease);
+		expect(getFhirRelease("r5")).toBeInstanceOf(R5Release);
+		expect(getFhirRelease("r6")).toBeNull();
+	});
+
+	it("keeps version-specific abstract target names explicit", () => {
+		expect(new STU3Release().abstractTargetNames).toEqual([
+			"BackboneElement",
+			"DomainResource",
+			"Element",
+			"Resource",
+		]);
+		expect(new R4Release().abstractTargetNames).toEqual([
+			"BackboneElement",
+			"DomainResource",
+			"Element",
+			"Resource",
+		]);
+		expect(new R4BRelease().abstractTargetNames).toContain("DataType");
+		expect(new R5Release().abstractTargetNames).toEqual(
+			expect.arrayContaining(["Base", "BackboneType", "DataType"]),
+		);
+	});
+
+	it("builds official example page URLs from release id and resource name", () => {
+		expect(new R4Release().exampleResourcePageUrl("Observation")).toBe(
+			"https://hl7.org/fhir/R4/observation-examples.html",
+		);
+		expect(new R4BRelease().exampleResourcePageUrl("Patient")).toBe(
+			"https://hl7.org/fhir/R4B/patient-examples.html",
+		);
+	});
+
+	it("summarizes synthetic target inventories", () => {
+		expect(new R5Release().summarizeTargets(syntheticEntries)).toEqual({
+			abstractGenerationWhitelist: [
+				"BackboneElement",
+				"BackboneType",
+				"Base",
+				"DataType",
+				"DomainResource",
+				"Element",
+				"Resource",
+			],
+			concreteResourceCount: 2,
+			coreResourceCount: 1,
+			generationTargetCount: 2,
+			profileResourceCount: 1,
+		});
+	});
+});

--- a/tests/helpers/r4-contract-fixtures.ts
+++ b/tests/helpers/r4-contract-fixtures.ts
@@ -1,0 +1,66 @@
+export function minimalObservation(): Record<string, unknown> {
+	return {
+		resourceType: "Observation",
+		status: "final",
+		code: { text: "Example observation" },
+	};
+}
+
+export function minimalExtension(): Record<string, unknown> {
+	return {
+		url: "http://example.test/fhir/StructureDefinition/example-extension",
+	};
+}
+
+export function minimalParameter(): Record<string, unknown> {
+	return {
+		name: "example",
+	};
+}
+
+export function minimalMeta(): Record<string, unknown> {
+	return {};
+}
+
+export function minimalElementDefinition(): Record<string, unknown> {
+	return {
+		path: "Patient.name",
+	};
+}
+
+export function minimalEncounter(): Record<string, unknown> {
+	return {
+		resourceType: "Encounter",
+		status: "finished",
+		class: { code: "AMB" },
+	};
+}
+
+export function minimalAccount(): Record<string, unknown> {
+	return {
+		resourceType: "Account",
+		status: "active",
+	};
+}
+
+export function minimalBundle(): Record<string, unknown> {
+	return {
+		resourceType: "Bundle",
+		type: "collection",
+	};
+}
+
+export function minimalQuantity(): Record<string, unknown> {
+	return {};
+}
+
+export function primitiveMetadata(): Record<string, unknown> {
+	return {
+		extension: [
+			{
+				url: "http://example.test/fhir/StructureDefinition/primitive-note",
+				valueString: "metadata only",
+			},
+		],
+	};
+}

--- a/tests/helpers/schema-contracts.ts
+++ b/tests/helpers/schema-contracts.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { z } from "zod";
+
+export type IssueExpectation = {
+	messageIncludes?: string;
+	path?: Array<string | number>;
+	pathEndsWith?: Array<string | number>;
+};
+
+export type PatchCase = IssueExpectation & {
+	name: string;
+	patch?: Record<string, unknown>;
+	omit?: string[];
+};
+
+export type ContractCase = {
+	name: string;
+	schema: z.ZodTypeAny;
+	base: () => Record<string, unknown>;
+	valid?: PatchCase[];
+	invalid?: PatchCase[];
+};
+
+export function expectValid(schema: z.ZodTypeAny, value: unknown): void {
+	const result = schema.safeParse(value);
+
+	if (!result.success) {
+		throw new Error(
+			`Expected validation success, received issues:\n${JSON.stringify(
+				result.error.issues,
+				null,
+				2,
+			)}`,
+		);
+	}
+}
+
+export function expectInvalid(
+	schema: z.ZodTypeAny,
+	value: unknown,
+	expected: IssueExpectation = {},
+): void {
+	const result = schema.safeParse(value);
+
+	if (result.success) {
+		throw new Error("Expected validation failure");
+	}
+
+	const { issues } = result.error;
+
+	if (expected.messageIncludes !== undefined) {
+		expect(issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					message: expect.stringContaining(expected.messageIncludes),
+				}),
+			]),
+		);
+	}
+
+	if (expected.path !== undefined) {
+		const expectedPath = expected.path;
+		expect(issues.some((issue) => pathEquals(issue.path, expectedPath))).toBe(
+			true,
+		);
+	}
+
+	if (expected.pathEndsWith !== undefined) {
+		const expectedPathEnd = expected.pathEndsWith;
+		expect(
+			issues.some((issue) => pathEndsWith(issue.path, expectedPathEnd)),
+		).toBe(true);
+	}
+}
+
+export function runSchemaContract(contract: ContractCase): void {
+	describe(contract.name, () => {
+		for (const testCase of contract.valid ?? []) {
+			it(`accepts ${testCase.name}`, () => {
+				expectValid(contract.schema, materializeCase(contract.base, testCase));
+			});
+		}
+
+		for (const testCase of contract.invalid ?? []) {
+			it(`rejects ${testCase.name}`, () => {
+				expectInvalid(
+					contract.schema,
+					materializeCase(contract.base, testCase),
+					testCase,
+				);
+			});
+		}
+	});
+}
+
+export function choiceContract(contract: ContractCase): void {
+	runSchemaContract(contract);
+}
+
+export function primitiveArrayContract(contract: ContractCase): void {
+	runSchemaContract(contract);
+}
+
+export function referenceContract(contract: ContractCase): void {
+	runSchemaContract(contract);
+}
+
+export function requiredFieldContract(contract: ContractCase): void {
+	runSchemaContract(contract);
+}
+
+function materializeCase(
+	base: () => Record<string, unknown>,
+	testCase: PatchCase,
+): Record<string, unknown> {
+	const value = {
+		...base(),
+		...(testCase.patch ?? {}),
+	};
+
+	for (const key of testCase.omit ?? []) {
+		delete value[key];
+	}
+
+	return value;
+}
+
+function pathEquals(
+	actual: Array<string | number>,
+	expected: Array<string | number>,
+): boolean {
+	return (
+		actual.length === expected.length &&
+		actual.every((segment, index) => segment === expected[index])
+	);
+}
+
+function pathEndsWith(
+	actual: Array<string | number>,
+	expected: Array<string | number>,
+): boolean {
+	return (
+		actual.length >= expected.length &&
+		expected.every(
+			(segment, index) =>
+				actual[actual.length - expected.length + index] === segment,
+		)
+	);
+}

--- a/tests/helpers/schema-contracts.ts
+++ b/tests/helpers/schema-contracts.ts
@@ -126,7 +126,7 @@ function materializeCase(
 }
 
 function pathEquals(
-	actual: Array<string | number>,
+	actual: PropertyKey[],
 	expected: Array<string | number>,
 ): boolean {
 	return (
@@ -136,7 +136,7 @@ function pathEquals(
 }
 
 function pathEndsWith(
-	actual: Array<string | number>,
+	actual: PropertyKey[],
 	expected: Array<string | number>,
 ): boolean {
 	return (

--- a/tests/package-config.test.ts
+++ b/tests/package-config.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import tsdownConfig from "../tsdown.config.ts";
+
+type PackageJson = {
+	exports: Record<string, unknown>;
+};
+
+describe("package and build config", () => {
+	it("exports the root package and supported version subpaths", () => {
+		const packageJson = JSON.parse(
+			readFileSync(resolve("package.json"), "utf8"),
+		) as PackageJson;
+
+		expect(Object.keys(packageJson.exports).sort()).toEqual([
+			".",
+			"./r4",
+			"./r4b",
+			"./r5",
+			"./stu3",
+		]);
+	});
+
+	it("builds each public entrypoint as unbundled ESM with declarations", () => {
+		expect(tsdownConfig).toMatchObject({
+			dts: true,
+			entry: {
+				index: "src/index.ts",
+				"r4/index": "src/r4/index.ts",
+				"r4b/index": "src/r4b/index.ts",
+				"r5/index": "src/r5/index.ts",
+				"stu3/index": "src/stu3/index.ts",
+			},
+			format: "esm",
+			outDir: "dist",
+			unbundle: true,
+		});
+	});
+});

--- a/tests/r4-choice-contracts.test.ts
+++ b/tests/r4-choice-contracts.test.ts
@@ -1,0 +1,135 @@
+import {
+	ExtensionSchema,
+	ObservationSchema,
+	Parameters_ParameterSchema,
+} from "fhir-zod/r4";
+import {
+	minimalExtension,
+	minimalObservation,
+	minimalParameter,
+} from "./helpers/r4-contract-fixtures.ts";
+import { choiceContract } from "./helpers/schema-contracts.ts";
+
+choiceContract({
+	name: "Observation.effective[x]",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	valid: [
+		{
+			name: "effectiveDateTime",
+			patch: { effectiveDateTime: "2020-01-01T00:00:00Z" },
+		},
+		{
+			name: "effectivePeriod",
+			patch: { effectivePeriod: { start: "2020-01-01" } },
+		},
+		{
+			name: "primitive metadata companion",
+			patch: {
+				effectiveDateTime: "2020-01-01T00:00:00Z",
+				_effectiveDateTime: { id: "effective-metadata" },
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "two variants",
+			patch: {
+				effectiveDateTime: "2020-01-01T00:00:00Z",
+				effectivePeriod: { start: "2020-01-01" },
+			},
+			messageIncludes: "effective[x]",
+		},
+	],
+});
+
+choiceContract({
+	name: "Observation.value[x]",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	valid: [
+		{
+			name: "valueString",
+			patch: { valueString: "positive" },
+		},
+		{
+			name: "valueQuantity",
+			patch: { valueQuantity: { value: 1, unit: "mg" } },
+		},
+		{
+			name: "primitive metadata companion",
+			patch: {
+				valueString: "positive",
+				_valueString: { id: "value-metadata" },
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "two variants",
+			patch: {
+				valueString: "positive",
+				valueBoolean: true,
+			},
+			messageIncludes: "value[x]",
+		},
+	],
+});
+
+choiceContract({
+	name: "Extension.value[x]",
+	schema: ExtensionSchema,
+	base: minimalExtension,
+	valid: [
+		{
+			name: "valueString",
+			patch: { valueString: "hello" },
+		},
+		{
+			name: "primitive metadata companion",
+			patch: {
+				valueString: "hello",
+				_valueString: { id: "value-metadata" },
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "two variants",
+			patch: {
+				valueString: "hello",
+				valueBoolean: true,
+			},
+			messageIncludes: "value[x]",
+		},
+	],
+});
+
+choiceContract({
+	name: "Parameters_Parameter.value[x]",
+	schema: Parameters_ParameterSchema,
+	base: minimalParameter,
+	valid: [
+		{
+			name: "valueString",
+			patch: { valueString: "hello" },
+		},
+		{
+			name: "primitive metadata companion",
+			patch: {
+				valueString: "hello",
+				_valueString: { id: "value-metadata" },
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "two variants",
+			patch: {
+				valueString: "hello",
+				valueBoolean: true,
+			},
+			messageIncludes: "value[x]",
+		},
+	],
+});

--- a/tests/r4-inheritance-required-contracts.test.ts
+++ b/tests/r4-inheritance-required-contracts.test.ts
@@ -1,0 +1,224 @@
+import {
+	AccountSchema,
+	BundleSchema,
+	EncounterSchema,
+	ObservationSchema,
+	QuantitySchema,
+} from "fhir-zod/r4";
+import {
+	minimalAccount,
+	minimalBundle,
+	minimalEncounter,
+	minimalObservation,
+	minimalQuantity,
+} from "./helpers/r4-contract-fixtures.ts";
+import {
+	requiredFieldContract,
+	runSchemaContract,
+} from "./helpers/schema-contracts.ts";
+
+runSchemaContract({
+	name: "Observation inherits DomainResource fields",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	valid: [
+		{
+			name: "text and extension",
+			patch: {
+				text: {
+					status: "generated",
+					div: '<div xmlns="http://www.w3.org/1999/xhtml">Example</div>',
+				},
+				extension: [
+					{
+						url: "http://example.test/fhir/StructureDefinition/observation-note",
+						valueString: "base extension",
+					},
+				],
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "unknown field",
+			patch: { unexpectedBaseField: true },
+			messageIncludes: "Unrecognized key",
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Bundle inherits Resource fields",
+	schema: BundleSchema,
+	base: minimalBundle,
+	valid: [
+		{
+			name: "id, meta, and language",
+			patch: {
+				id: "bundle-1",
+				meta: {
+					profile: [
+						"http://example.test/fhir/StructureDefinition/bundle-profile",
+					],
+				},
+				language: "en",
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "unknown field",
+			patch: { unexpected: true },
+			messageIncludes: "Unrecognized key",
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Quantity inherits Element fields",
+	schema: QuantitySchema,
+	base: minimalQuantity,
+	valid: [
+		{
+			name: "id, extension, and own fields",
+			patch: {
+				id: "quantity-1",
+				extension: [
+					{
+						url: "http://example.test/fhir/StructureDefinition/quantity-note",
+						valueString: "metadata",
+					},
+				],
+				value: 1.23,
+				unit: "mg",
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "unknown field",
+			patch: { unexpected: true },
+			messageIncludes: "Unrecognized key",
+		},
+	],
+});
+
+requiredFieldContract({
+	name: "Observation required fields",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	invalid: [
+		{
+			name: "missing status",
+			omit: ["status"],
+			path: ["status"],
+		},
+		{
+			name: "missing code",
+			omit: ["code"],
+			path: ["code"],
+		},
+	],
+});
+
+requiredFieldContract({
+	name: "Encounter required fields",
+	schema: EncounterSchema,
+	base: minimalEncounter,
+	invalid: [
+		{
+			name: "missing status",
+			omit: ["status"],
+			path: ["status"],
+		},
+		{
+			name: "missing class",
+			omit: ["class"],
+			path: ["class"],
+		},
+	],
+});
+
+requiredFieldContract({
+	name: "Account required fields",
+	schema: AccountSchema,
+	base: minimalAccount,
+	invalid: [
+		{
+			name: "missing status",
+			omit: ["status"],
+			path: ["status"],
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Required enum bindings",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	invalid: [
+		{
+			name: "Observation invalid status",
+			patch: { status: "not-a-status" },
+			path: ["status"],
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Encounter required enum bindings",
+	schema: EncounterSchema,
+	base: minimalEncounter,
+	invalid: [
+		{
+			name: "Encounter invalid status",
+			patch: { status: "not-a-status" },
+			path: ["status"],
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Account required enum bindings",
+	schema: AccountSchema,
+	base: minimalAccount,
+	invalid: [
+		{
+			name: "Account invalid status",
+			patch: { status: "not-a-status" },
+			path: ["status"],
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Bundle required enum bindings",
+	schema: BundleSchema,
+	base: minimalBundle,
+	invalid: [
+		{
+			name: "Bundle invalid type",
+			patch: { type: "not-a-bundle-type" },
+			path: ["type"],
+		},
+	],
+});
+
+runSchemaContract({
+	name: "Encounter required backbone child",
+	schema: EncounterSchema,
+	base: minimalEncounter,
+	invalid: [
+		{
+			name: "missing location reference",
+			patch: {
+				location: [
+					{
+						status: "active",
+					},
+				],
+			},
+			pathEndsWith: ["location", 0, "location"],
+		},
+	],
+});

--- a/tests/r4-primitive-array-contracts.test.ts
+++ b/tests/r4-primitive-array-contracts.test.ts
@@ -1,0 +1,103 @@
+import { ElementDefinitionSchema, MetaSchema } from "fhir-zod/r4";
+import {
+	minimalElementDefinition,
+	minimalMeta,
+	primitiveMetadata,
+} from "./helpers/r4-contract-fixtures.ts";
+import { primitiveArrayContract } from "./helpers/schema-contracts.ts";
+
+primitiveArrayContract({
+	name: "Meta.profile/_profile",
+	schema: MetaSchema,
+	base: minimalMeta,
+	valid: [
+		{
+			name: "equal value and metadata arrays",
+			patch: {
+				profile: ["http://example.test/fhir/StructureDefinition/a"],
+				_profile: [primitiveMetadata()],
+			},
+		},
+		{
+			name: "metadata array longer than value array with content",
+			patch: {
+				profile: ["http://example.test/fhir/StructureDefinition/a"],
+				_profile: [null, primitiveMetadata()],
+			},
+		},
+		{
+			name: "value array longer than metadata array with non-null values",
+			patch: {
+				profile: [
+					"http://example.test/fhir/StructureDefinition/a",
+					"http://example.test/fhir/StructureDefinition/b",
+				],
+				_profile: [null],
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "metadata-only empty object",
+			patch: { _profile: [{}] },
+			messageIncludes:
+				"profile[0] has neither a primitive value nor _profile[0] metadata",
+			path: ["_profile", 0],
+		},
+		{
+			name: "null value with empty metadata",
+			patch: {
+				profile: [null],
+				_profile: [{}],
+			},
+			messageIncludes:
+				"profile[0] has neither a primitive value nor _profile[0] metadata",
+			path: ["profile", 0],
+		},
+	],
+});
+
+primitiveArrayContract({
+	name: "ElementDefinition.alias/_alias",
+	schema: ElementDefinitionSchema,
+	base: minimalElementDefinition,
+	valid: [
+		{
+			name: "alias value only",
+			patch: { alias: ["official name"] },
+		},
+		{
+			name: "metadata array longer than alias array with content",
+			patch: {
+				alias: ["official name"],
+				_alias: [null, primitiveMetadata()],
+			},
+		},
+		{
+			name: "alias array longer than metadata array with non-null values",
+			patch: {
+				alias: ["official name", "display name"],
+				_alias: [null],
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "metadata-only empty object",
+			patch: { _alias: [{}] },
+			messageIncludes:
+				"alias[0] has neither a primitive value nor _alias[0] metadata",
+			path: ["_alias", 0],
+		},
+		{
+			name: "null alias with empty metadata",
+			patch: {
+				alias: [null],
+				_alias: [{}],
+			},
+			messageIncludes:
+				"alias[0] has neither a primitive value nor _alias[0] metadata",
+			path: ["alias", 0],
+		},
+	],
+});

--- a/tests/r4-reference-contracts.test.ts
+++ b/tests/r4-reference-contracts.test.ts
@@ -1,0 +1,142 @@
+import { ObservationSchema } from "fhir-zod/r4";
+import { minimalObservation } from "./helpers/r4-contract-fixtures.ts";
+import { referenceContract } from "./helpers/schema-contracts.ts";
+
+referenceContract({
+	name: "Observation.encounter constrained reference",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	valid: [
+		{
+			name: "relative allowed reference",
+			patch: { encounter: { reference: "Encounter/example" } },
+		},
+		{
+			name: "absolute allowed FHIR URL",
+			patch: {
+				encounter: { reference: "https://example.test/fhir/Encounter/example" },
+			},
+		},
+		{
+			name: "history URL",
+			patch: { encounter: { reference: "Encounter/example/_history/1" } },
+		},
+		{
+			name: "internal reference without type",
+			patch: { encounter: { reference: "#enc1" } },
+		},
+		{
+			name: "internal reference with allowed canonical type",
+			patch: {
+				encounter: {
+					reference: "#enc1",
+					type: "http://hl7.org/fhir/StructureDefinition/Encounter",
+				},
+			},
+		},
+		{
+			name: "URN reference without type",
+			patch: {
+				encounter: {
+					reference: "urn:uuid:12345678-1234-1234-1234-123456789abc",
+				},
+			},
+		},
+		{
+			name: "bare allowed type without reference",
+			patch: { encounter: { type: "Encounter" } },
+		},
+		{
+			name: "canonical allowed type without reference",
+			patch: {
+				encounter: {
+					type: "http://hl7.org/fhir/StructureDefinition/Encounter",
+				},
+			},
+		},
+	],
+	invalid: [
+		{
+			name: "disallowed relative reference",
+			patch: { encounter: { reference: "Patient/example" } },
+			messageIncludes: "Expected encounter to reference one of: Encounter",
+			path: ["encounter", "reference"],
+		},
+		{
+			name: "disallowed absolute FHIR URL",
+			patch: {
+				encounter: { reference: "https://example.test/fhir/Patient/example" },
+			},
+			messageIncludes: "Expected encounter to reference one of: Encounter",
+		},
+		{
+			name: "disallowed history URL",
+			patch: { encounter: { reference: "Patient/example/_history/1" } },
+			messageIncludes: "Expected encounter to reference one of: Encounter",
+		},
+		{
+			name: "internal reference with disallowed canonical type",
+			patch: {
+				encounter: {
+					reference: "#enc1",
+					type: "http://hl7.org/fhir/StructureDefinition/Patient",
+				},
+			},
+			messageIncludes: "Expected encounter.type to be one of: Encounter",
+			path: ["encounter", "type"],
+		},
+		{
+			name: "URN reference with disallowed type",
+			patch: {
+				encounter: {
+					reference: "urn:uuid:12345678-1234-1234-1234-123456789abc",
+					type: "Patient",
+				},
+			},
+			messageIncludes: "Expected encounter.type to be one of: Encounter",
+		},
+		{
+			name: "bare disallowed type",
+			patch: { encounter: { type: "Patient" } },
+			messageIncludes: "Expected encounter.type to be one of: Encounter",
+		},
+		{
+			name: "reference/type mismatch",
+			patch: {
+				encounter: {
+					reference: "Encounter/example",
+					type: "Patient",
+				},
+			},
+			messageIncludes: "Reference.type and reference disagree for encounter",
+			path: ["encounter", "reference"],
+		},
+	],
+});
+
+referenceContract({
+	name: "Observation.focus Resource target short-circuit",
+	schema: ObservationSchema,
+	base: minimalObservation,
+	valid: [
+		{
+			name: "Patient focus",
+			patch: { focus: [{ reference: "Patient/example" }] },
+		},
+		{
+			name: "Organization focus",
+			patch: { focus: [{ reference: "Organization/example" }] },
+		},
+		{
+			name: "unrecognized type accepted because target is Resource",
+			patch: {
+				focus: [
+					{
+						reference: "Patient/example",
+						type: "http://example.test/StructureDefinition/NotFHIR",
+					},
+				],
+			},
+		},
+	],
+});

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -157,9 +157,9 @@ describe("list-targets script", () => {
 });
 
 describe("fetch-spec script", () => {
-	it("selects R4 by default and explicit versions when requested", () => {
+	it("selects R4 by default, all manifests, and explicit versions when requested", () => {
 		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
-		for (const version of ["r4", "r5"]) {
+		for (const version of ["r4", "r4b", "r5", "stu3"]) {
 			const specDir = join(repoRoot, "src", "spec", version);
 			mkdirSync(specDir, { recursive: true });
 			writeFileSync(
@@ -174,6 +174,11 @@ describe("fetch-spec script", () => {
 		expect(loadManifests({ repoRoot }).map((item) => item.version)).toEqual([
 			"r4",
 		]);
+		expect(
+			loadManifests({ repoRoot, requestedVersions: ["all"] }).map(
+				(item) => item.version,
+			),
+		).toEqual(["r4", "r4b", "r5", "stu3"]);
 		expect(
 			loadManifests({ repoRoot, requestedVersions: ["r5"] }).map(
 				(item) => item.version,

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -1,0 +1,421 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	assertNotHumanVerification,
+	collectPositionalArgs,
+	decodeHtmlEntities,
+	discoverJsonExamples,
+	normalizeTextFileContent,
+	parseFetchExamplesOptions,
+	parseNumberFlag,
+	runFetchExamplesCli,
+	selectResourceNames,
+} from "../scripts/fetch-examples.ts";
+import {
+	basenameFromUrl,
+	ensureJsonSchema,
+	ensurePackage,
+	type FetchSpecDependencies,
+	isPackageReady,
+	loadManifests,
+	runFetchSpecCli,
+	type SpecManifest,
+} from "../scripts/fetch-spec.ts";
+import { runGenerateCli } from "../scripts/generate.ts";
+import { runListTargetsCli } from "../scripts/list-targets.ts";
+import type { FhirRelease, TargetEntry } from "../src/generator/versions.ts";
+
+function manifest(overrides: Partial<SpecManifest> = {}): SpecManifest {
+	return {
+		fhirVersion: "4.0.1",
+		packageName: "hl7.fhir.r4.core",
+		packageRoot: ".local/spec-cache/r4/package",
+		packageVersion: "4.0.1",
+		sourceUrl: "https://example.test/package.tgz",
+		structureDefinitionGlob: "StructureDefinition-*.json",
+		...overrides,
+	};
+}
+
+function fakeRelease(id = "r4"): FhirRelease {
+	const entries: TargetEntry[] = [
+		{
+			abstract: true,
+			baseDefinition: null,
+			category: "abstract-whitelist",
+			kind: "complex-type",
+			name: "Element",
+			shouldGenerate: true,
+			type: "Element",
+			url: null,
+		},
+		{
+			abstract: false,
+			baseDefinition: null,
+			category: "core-resource",
+			kind: "resource",
+			name: "Patient",
+			shouldGenerate: true,
+			type: "Patient",
+			url: null,
+		},
+		{
+			abstract: false,
+			baseDefinition: null,
+			category: "profile-resource",
+			kind: "resource",
+			name: "ExampleProfile",
+			shouldGenerate: false,
+			type: "Patient",
+			url: null,
+		},
+		{
+			abstract: false,
+			baseDefinition: null,
+			category: "other",
+			kind: "complex-type",
+			name: "Address",
+			shouldGenerate: false,
+			type: "Address",
+			url: null,
+		},
+	];
+
+	return {
+		abstractTargetNames: ["Element"],
+		exampleResourcePageUrl: (resourceName: string) =>
+			`https://example.test/${id}/${resourceName.toLowerCase()}-examples.html`,
+		generate: () => ({ files: [`src/${id}/Patient.ts`] }),
+		id,
+		label: id.toUpperCase(),
+		listCoreResourceNames: () => ["Patient", "Observation"],
+		loadTargetEntries: () => entries,
+		nestedBackboneTypeCodes: ["Element"],
+		summarizeTargets: () => ({
+			abstractGenerationWhitelist: ["Element"],
+			concreteResourceCount: 2,
+			coreResourceCount: 1,
+			generationTargetCount: 2,
+			profileResourceCount: 1,
+		}),
+	} as unknown as FhirRelease;
+}
+
+describe("list-targets script", () => {
+	it("defaults to R4, supports wrappers, filters, and names-only output", () => {
+		const logs: string[] = [];
+		const getRelease = (version: string) =>
+			version === "r4" || version === "r4b" ? fakeRelease(version) : null;
+
+		runListTargetsCli(undefined, {
+			argv: ["--summary"],
+			getRelease,
+			log: (message) => logs.push(message),
+		});
+		expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+			outputMode: "summary",
+			version: "r4",
+		});
+
+		runListTargetsCli("r4b", {
+			argv: ["--names-only", "--category", "core-resource"],
+			getRelease,
+			log: (message) => logs.push(message),
+		});
+		expect(logs.at(-1)).toBe("Patient");
+
+		runListTargetsCli(undefined, {
+			argv: ["r4", "--category=not-real"],
+			getRelease,
+			log: (message) => logs.push(message),
+		});
+		expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+			categoryFilter: "all",
+			filteredCount: 4,
+		});
+	});
+
+	it("throws a clear error for unknown versions", () => {
+		expect(() =>
+			runListTargetsCli(undefined, {
+				argv: ["r6"],
+				getRelease: () => null,
+				log: () => undefined,
+			}),
+		).toThrow('Unknown target inventory version "r6"');
+	});
+});
+
+describe("fetch-spec script", () => {
+	it("selects R4 by default and explicit versions when requested", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
+		for (const version of ["r4", "r5"]) {
+			const specDir = join(repoRoot, "src", "spec", version);
+			mkdirSync(specDir, { recursive: true });
+			writeFileSync(
+				join(specDir, "manifest.json"),
+				JSON.stringify(
+					manifest({ packageRoot: `.local/spec-cache/${version}/package` }),
+				),
+				"utf8",
+			);
+		}
+
+		expect(loadManifests({ repoRoot }).map((item) => item.version)).toEqual([
+			"r4",
+		]);
+		expect(
+			loadManifests({ repoRoot, requestedVersions: ["r5"] }).map(
+				(item) => item.version,
+			),
+		).toEqual(["r5"]);
+	});
+
+	it("detects package readiness from Patient StructureDefinition and JSON schema output", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
+		const packageDir = join(repoRoot, ".local", "spec-cache", "r4", "package");
+		mkdirSync(packageDir, { recursive: true });
+
+		expect(isPackageReady(packageDir, manifest(), { repoRoot })).toBe(false);
+		writeFileSync(
+			join(packageDir, "StructureDefinition-Patient.json"),
+			"{}",
+			"utf8",
+		);
+		expect(isPackageReady(packageDir, manifest(), { repoRoot })).toBe(true);
+		expect(
+			isPackageReady(
+				packageDir,
+				manifest({ jsonSchemaOutputPath: ".local/schema/fhir.schema.json" }),
+				{ repoRoot },
+			),
+		).toBe(false);
+	});
+
+	it("uses cached JSON schema and builds archive names from URLs", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
+		const outputPath = join(repoRoot, ".local", "schema", "fhir.schema.json");
+		mkdirSync(join(repoRoot, ".local", "schema"), { recursive: true });
+		writeFileSync(outputPath, "{}", "utf8");
+		const execCalls: string[] = [];
+
+		ensureJsonSchema(
+			join(repoRoot, ".local", "downloads"),
+			manifest({
+				jsonSchemaArchiveEntry: "fhir.schema.json",
+				jsonSchemaOutputPath: ".local/schema/fhir.schema.json",
+				jsonSchemaSourceUrl: "https://example.test/path/fhir-json.zip",
+			}),
+			{
+				deps: {
+					...makeFetchSpecDeps(execCalls),
+				},
+				repoRoot,
+			},
+		);
+
+		expect(execCalls).toEqual([]);
+		expect(basenameFromUrl("https://example.test/path/fhir-json.zip")).toBe(
+			"fhir-json.zip",
+		);
+	});
+
+	it("downloads package archives only on cache misses", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
+		const execCalls: string[] = [];
+		const deps = makeFetchSpecDeps(execCalls);
+
+		ensurePackage("r4", "manifest.json", manifest(), { deps, repoRoot });
+
+		expect(execCalls).toEqual(["curl", "tar"]);
+	});
+
+	it("runs the CLI through injected dependencies", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-spec-"));
+		const specDir = join(repoRoot, "src", "spec", "r4");
+		const packageDir = join(repoRoot, ".local", "spec-cache", "r4", "package");
+		const execCalls: string[] = [];
+		mkdirSync(specDir, { recursive: true });
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(
+			join(packageDir, "StructureDefinition-Patient.json"),
+			"{}",
+			"utf8",
+		);
+		writeFileSync(
+			join(specDir, "manifest.json"),
+			JSON.stringify(manifest()),
+			"utf8",
+		);
+
+		runFetchSpecCli([], {
+			deps: makeFetchSpecDeps(execCalls),
+			repoRoot,
+		});
+
+		expect(execCalls).toEqual([]);
+	});
+});
+
+describe("fetch-examples script", () => {
+	it("parses args, flags, and invalid numeric values", () => {
+		const deps = { getRelease: () => fakeRelease() };
+
+		expect(
+			parseFetchExamplesOptions(
+				["r4", "patient", "--force", "--delay-ms=0", "--limit", "1"],
+				deps,
+			),
+		).toMatchObject({
+			delayMs: 0,
+			forceRefresh: true,
+			limit: 1,
+			requestedResources: ["Patient"],
+			version: "r4",
+		});
+		expect(collectPositionalArgs(["r4", "--limit", "1", "patient"])).toEqual([
+			"r4",
+			"patient",
+		]);
+		expect(() => parseNumberFlag(["--limit=no"], "--limit")).toThrow(
+			"Expected --limit to be a non-negative integer",
+		);
+	});
+
+	it("discovers JSON links and decodes HTML entities", () => {
+		const release = fakeRelease();
+		const links = discoverJsonExamples(
+			release,
+			"Patient",
+			'<a href="patient-example.json.html">one</a><a href="/Patient-two.json.html?x=1&amp;y=2">two</a>',
+		);
+
+		expect(links.map((link) => link.filename)).toEqual([
+			"patient-example.json",
+		]);
+		expect(decodeHtmlEntities("a&amp;b&quot;c&#39;d&lt;e&gt;")).toBe(
+			"a&b\"c'd<e>",
+		);
+		expect(normalizeTextFileContent("x\r\n\n")).toBe("x\n");
+	});
+
+	it("validates resource names and human-verification pages", () => {
+		expect(selectResourceNames(["patient"], ["Patient"], "r4")).toEqual([
+			"Patient",
+		]);
+		expect(() => selectResourceNames(["Missing"], ["Patient"], "r4")).toThrow(
+			"Unknown R4 resource",
+		);
+		expect(() =>
+			assertNotHumanVerification(
+				"<title>Human Verification</title>",
+				"https://example.test",
+			),
+		).toThrow("Human verification blocked automated fetches");
+	});
+
+	it("leaves fixture dirs untouched when no examples are discovered", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-examples-"));
+		const logs: string[] = [];
+		const warnings: string[] = [];
+		const rmCalls: string[] = [];
+
+		runFetchExamplesCli(["r4", "Patient", "--force", "--delay-ms=0"], {
+			deps: {
+				execFileSync: (() => "<html>No examples</html>") as never,
+				getRelease: () => fakeRelease(),
+				log: (message) => logs.push(message),
+				rmSync: (path) => rmCalls.push(String(path)),
+				warn: (message) => warnings.push(message),
+			},
+			repoRoot,
+		});
+
+		expect(rmCalls).toEqual([]);
+		expect(warnings.join("\n")).toContain("No JSON examples discovered");
+		expect(logs.at(-1)).toContain("noExamples=1");
+	});
+
+	it("clears and rewrites fixture dirs when examples are fetched", () => {
+		const repoRoot = mkdtempSync(join(tmpdir(), "fhir-zod-fetch-examples-"));
+		const responses = [
+			'<a href="patient-example.json.html">example</a>',
+			'{"resourceType":"Patient"}',
+		];
+
+		runFetchExamplesCli(["r4", "Patient", "--force", "--delay-ms=0"], {
+			deps: {
+				execFileSync: (() => responses.shift() ?? "") as never,
+				getRelease: () => fakeRelease(),
+				log: () => undefined,
+				warn: () => undefined,
+			},
+			repoRoot,
+		});
+
+		expect(
+			readFileSync(
+				join(
+					repoRoot,
+					"tests",
+					"fixtures",
+					"r4",
+					"Patient",
+					"patient-example.json",
+				),
+				"utf8",
+			),
+		).toBe('{"resourceType":"Patient"}\n');
+	});
+});
+
+describe("generate script", () => {
+	it("defaults to R4, accepts multiple versions, logs files, and rejects unknown versions", () => {
+		const requestedVersions: string[] = [];
+		const logs: string[] = [];
+		const getRelease = (version: string) => {
+			requestedVersions.push(version);
+			return version === "r6" ? null : fakeRelease(version);
+		};
+
+		runGenerateCli([], { getRelease, log: (message) => logs.push(message) });
+		runGenerateCli(["r4b", "r5"], {
+			getRelease,
+			log: (message) => logs.push(message),
+		});
+
+		expect(requestedVersions).toEqual(["r4", "r4b", "r5"]);
+		expect(logs).toEqual([
+			"generated src/r4/Patient.ts",
+			"generated src/r4b/Patient.ts",
+			"generated src/r5/Patient.ts",
+		]);
+		expect(() => runGenerateCli(["r6"], { getRelease })).toThrow(
+			'Unknown generation target "r6"',
+		);
+	});
+});
+
+function makeFetchSpecDeps(execCalls: string[]): FetchSpecDependencies {
+	return {
+		execFileSync: ((command) => {
+			execCalls.push(String(command));
+			return Buffer.from("");
+		}) as FetchSpecDependencies["execFileSync"],
+		existsSync,
+		mkdirSync,
+		readdirSync,
+		readFileSync,
+		rmSync,
+	};
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,8 @@ export default defineConfig({
 	},
 	test: {
 		coverage: {
-			reporter: ["text", "lcov"],
+			include: ["src/**/*.ts", "scripts/**/*.ts", "tsdown.config.ts"],
+			reporter: ["text", "lcov", "json-summary"],
 		},
 		environment: "node",
 		outputFile: {


### PR DESCRIPTION
# Summary

Part of https://github.com/alysivji/fhir-zod/issues/23. Increase handwritten coverage around script entrypoints, generator helpers, and R4 runtime schema contracts. This adds deterministic tests for version-aware scripts plus a reusable table-driven schema contract harness for high-risk R4 validation behavior.

## Changes

- Add injected-dependency coverage for fetch, generate, list-targets, package config, generator model, and release registry behavior.
- Add `fetch-spec:all` and document it in the README command list.
- Add R4 schema contract helpers and curated contracts for choices, primitive arrays, references, inheritance, required fields, enum bindings, and strict unknown-field rejection.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm test
npm run check
npm run coverage
```

All commands passed. The local spec cache was present, so spec-backed target and generator provenance suites ran instead of skipping.

## Docs

- [ ] No docs update needed
- [x] Docs updated
