### PR TITLE
Reduce official example test tasks

### DIFF
--- a/tests/helpers/official-examples-suite.ts
+++ b/tests/helpers/official-examples-suite.ts
@@ -91,31 +91,58 @@ export function describeOfficialExamplesSuite(
 	}
 
 	describe(`${options.label} official examples`, () => {
-		for (const resourceName of readdirSync(options.fixturesRoot).sort()) {
-			const resourceDir = join(options.fixturesRoot, resourceName);
-			const entries = readdirSync(resourceDir, { withFileTypes: true });
+		const resourceDirs = readdirSync(options.fixturesRoot, {
+			withFileTypes: true,
+		})
+			.filter((entry) => entry.isDirectory())
+			.sort((left, right) => left.name.localeCompare(right.name));
 
-			for (const entry of entries.sort((left, right) =>
-				left.name.localeCompare(right.name),
-			)) {
-				if (!entry.isFile() || !entry.name.endsWith(".json")) {
-					continue;
-				}
+		for (const resourceEntry of resourceDirs) {
+			const resourceName = resourceEntry.name;
 
-				const fixturePath = join(resourceDir, entry.name);
-				const fixtureKey = relative(options.fixturesRoot, fixturePath);
-				const expectedFailure = options.expectedFailures.get(fixtureKey);
-				const testFn = expectedFailure ? it.fails : it;
+			it(`parses ${resourceName} examples`, () => {
+				const resourceDir = join(options.fixturesRoot, resourceName);
+				const entries = readdirSync(resourceDir, { withFileTypes: true });
+				const failures: Array<string> = [];
 
-				testFn(`parses ${fixtureKey}`, () => {
+				for (const entry of entries.sort((left, right) =>
+					left.name.localeCompare(right.name),
+				)) {
+					if (!entry.isFile() || !entry.name.endsWith(".json")) {
+						continue;
+					}
+
+					const fixturePath = join(resourceDir, entry.name);
+					const fixtureKey = relative(options.fixturesRoot, fixturePath);
+					const expectedFailure = options.expectedFailures.get(fixtureKey);
 					const input = JSON.parse(
 						readFileSync(fixturePath, "utf8"),
 					) as unknown;
 					const result = validateResourcePayload(input, fixtureKey);
 
-					expect(result.success, JSON.stringify(result, null, 2)).toBe(true);
-				});
-			}
+					if (expectedFailure) {
+						if (result.success) {
+							failures.push(
+								`${fixtureKey} parsed successfully but is still listed as an expected failure: ${expectedFailure}`,
+							);
+						}
+
+						continue;
+					}
+
+					if (!result.success) {
+						failures.push(
+							`${fixtureKey} failed unexpectedly:\n${JSON.stringify(
+								result,
+								null,
+								2,
+							)}`,
+						);
+					}
+				}
+
+				expect(failures, failures.join("\n\n")).toEqual([]);
+			});
 		}
 	});
 }

--- a/tests/official-example-expected-failures.test.ts
+++ b/tests/official-example-expected-failures.test.ts
@@ -16,8 +16,8 @@ describe("official example expected failures needing investigation", () => {
 		for (const [fixtureKey, reason] of expectedFailures) {
 			it.skip(`${version} ${fixtureKey}: ${reason}`, () => {
 				// Tracked as a skipped test so expected-failure debt stays visible in
-				// test summaries while the real fixture validation still runs under
-				// it.fails in the version-specific official-example suite.
+				// test summaries while the version-specific official-example suite
+				// still fails if the fixture starts passing.
 			});
 		}
 	}


### PR DESCRIPTION
# Summary

Batch official example validation by resource directory to avoid Vitest worker RPC timeouts from thousands of per-fixture task updates. The suites still validate every JSON fixture and still fail when an expected failure unexpectedly starts passing.

## Changes

- Group official example fixtures into one Vitest test per resource directory while preserving fixture-level failure messages.
- Update the expected-failure debt comment to reflect the new explicit expected-failure handling.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run fetch-spec:all
npx vitest run tests/stu3-official-examples.test.ts tests/r4-official-examples.test.ts tests/r4b-official-examples.test.ts tests/r5-official-examples.test.ts tests/official-example-expected-failures.test.ts
CI=1 npm test
npm run build
npm run check
```

## Docs

- [x] No docs update needed
- [ ] Docs updated
