### PR TITLE
Add Bun and Deno runtime compatibility tests

### DIFF
--- a/.github/workflows/runtime-compat.yml
+++ b/.github/workflows/runtime-compat.yml
@@ -1,0 +1,77 @@
+name: Runtime Compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * 1"
+
+jobs:
+  smoke:
+    name: ${{ matrix.runtime }} / Zod ${{ matrix.zod-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime:
+          - bun
+          - deno
+        zod-version:
+          - 3.25.1
+          - 4
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Set up Bun
+        if: ${{ matrix.runtime == 'bun' }}
+        uses: oven-sh/setup-bun@v2
+
+      - name: Set up Deno
+        if: ${{ matrix.runtime == 'deno' }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Select build-time Zod version
+        run: npm install --no-save --package-lock=false zod@${{ matrix.zod-version }}
+
+      - name: Build package
+        run: npm run build
+
+      - name: Pack package
+        run: |
+          mkdir -p .runtime-consumer/tests
+          npm pack --ignore-scripts --pack-destination .runtime-consumer
+          cp tests/runtime-smoke.mjs .runtime-consumer/runtime-smoke.mjs
+          cp tests/runtime-official-examples.mjs .runtime-consumer/runtime-official-examples.mjs
+          cp -R tests/fixtures .runtime-consumer/tests/fixtures
+
+      - name: Install packed package in consumer project
+        working-directory: .runtime-consumer
+        run: |
+          npm init -y
+          npm install --package-lock=false ./fhir-zod-*.tgz zod@${{ matrix.zod-version }}
+
+      - name: Run Bun smoke test
+        if: ${{ matrix.runtime == 'bun' }}
+        working-directory: .runtime-consumer
+        run: |
+          bun run runtime-smoke.mjs
+          bun run runtime-official-examples.mjs
+
+      - name: Run Deno smoke test
+        if: ${{ matrix.runtime == 'deno' }}
+        working-directory: .runtime-consumer
+        run: |
+          deno run --node-modules-dir=manual --allow-read runtime-smoke.mjs
+          deno run --node-modules-dir=manual --allow-read runtime-official-examples.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,17 @@ npm run check
 npm test
 ```
 
+`npm run test:runtime` is a package-consumer runtime test. Run it after
+`npm run build`; it imports the built package through public exports, checks a
+few library-level schema behaviors, and parses the committed official example
+fixtures without Vitest.
+
+The main CI workflow runs the Node/Zod matrix on pushes and pull requests.
+Bun and Deno are covered by the Runtime Compatibility workflow on a weekly
+schedule and through manual `workflow_dispatch` runs. Those jobs install the
+packed package in a fresh consumer project and run the same runtime tests with
+Zod 3.25.1 and Zod 4.
+
 Generator-side tests that need extracted spec packages skip cleanly on a fresh
 checkout. That is expected for contributors who have not populated `.local`.
 Run `npm run fetch-spec` when working on R4 generator behavior, or

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Generated TypeScript models and Zod schemas for HL7 FHIR.
 
 ![HL7 FHIR](https://img.shields.io/badge/HL7%20FHIR-compatible-blue) ![FHIR R5](https://img.shields.io/badge/FHIR-R5-purple) ![FHIR R4B](https://img.shields.io/badge/FHIR-R4B-blue) ![FHIR R4](https://img.shields.io/badge/FHIR-R4-green) ![FHIR STU3](https://img.shields.io/badge/FHIR-STU3-lightgrey)
 
-![Node](https://img.shields.io/badge/Node-%3E%3D20-339933?logo=node.js&logoColor=white) ![Zod](https://img.shields.io/badge/Zod-3.25.x%20%7C%204.x.x-3068B7?logo=zod&logoColor=white)
+![Node](https://img.shields.io/badge/Node-%3E%3D20-339933?logo=node.js&logoColor=white) ![Bun](https://img.shields.io/badge/Bun-%3E%3D1.3-000000?logo=bun&logoColor=white) ![Deno](https://img.shields.io/badge/Deno-%3E%3D2-000000?logo=deno&logoColor=white) ![Zod](https://img.shields.io/badge/Zod-3.25.x%20%7C%204.x.x-3068B7?logo=zod&logoColor=white)
 
-[![CI](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml/badge.svg)](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/alysivji/fhir-zod/graph/badge.svg)](https://codecov.io/gh/alysivji/fhir-zod) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Code style: Biome](https://img.shields.io/badge/code%20style-biome-60a5fa)](https://biomejs.dev/)
+[![CI](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml/badge.svg)](https://github.com/alysivji/fhir-zod/actions/workflows/ci.yml) [![Runtime Compatibility](https://github.com/alysivji/fhir-zod/actions/workflows/runtime-compat.yml/badge.svg)](https://github.com/alysivji/fhir-zod/actions/workflows/runtime-compat.yml) [![codecov](https://codecov.io/gh/alysivji/fhir-zod/graph/badge.svg)](https://codecov.io/gh/alysivji/fhir-zod) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Code style: Biome](https://img.shields.io/badge/code%20style-biome-60a5fa)](https://biomejs.dev/)
 
 `fhir-zod` gives you type-safe FHIR models for your editor and Zod schemas for your runtime. The generated output is versioned by FHIR release, so R5, R4B, R4, and STU3 stay explicit in your imports.
 
@@ -34,6 +34,46 @@ npm install fhir-zod zod
 ```
 
 Works with [Zod](https://zod.dev/) 3.25.x and 4.x.x.
+
+The published ESM library supports Node.js 20+, Bun 1.3+, and Deno 2+ for
+public package imports, model construction, and schema parsing. The generator
+and repository developer scripts are Node.js tooling.
+
+Runtime compatibility is tested by installing the packed npm package in a fresh
+consumer project and parsing the committed official FHIR example fixtures with
+Zod 3.25.x and Zod 4.x.x.
+
+## Runtime usage
+
+The published package is ESM-only. Use public imports such as `fhir-zod`,
+`fhir-zod/r4`, `fhir-zod/r4b`, `fhir-zod/r5`, and `fhir-zod/stu3`.
+
+Node.js:
+
+```bash
+npm install fhir-zod zod
+node app.mjs
+```
+
+Bun:
+
+```bash
+bun add fhir-zod zod
+bun run app.ts
+```
+
+Deno:
+
+```bash
+deno add npm:fhir-zod npm:zod
+deno run --node-modules-dir=auto app.ts
+```
+
+In all supported runtimes, application code imports the same package entrypoints:
+
+```ts
+import { PatientSchema, type Patient } from "fhir-zod/r4"
+```
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
 		"pack:check": "npm pack --dry-run",
 		"prepack": "npm run build",
 		"test": "vitest run",
+		"test:runtime": "node tests/runtime-smoke.mjs && node tests/runtime-official-examples.mjs",
+		"test:runtime:examples": "node tests/runtime-official-examples.mjs",
 		"typecheck": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc --noEmit"
 	},
 	"peerDependencies": {

--- a/tests/runtime-official-examples.mjs
+++ b/tests/runtime-official-examples.mjs
@@ -1,0 +1,235 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import * as r4Schemas from "fhir-zod/r4";
+import * as r4bSchemas from "fhir-zod/r4b";
+import * as r5Schemas from "fhir-zod/r5";
+import * as stu3Schemas from "fhir-zod/stu3";
+
+const expectedFailureGroups = {
+	stu3: new Map(),
+	r4: new Map([
+		[
+			"DeviceMetric/devicemetric-example.json",
+			"Official example references DeviceDefinition in parent, but the base R4 DeviceMetric constraint allows only Device.",
+		],
+		[
+			"DeviceUseStatement/deviceusestatement-example.json",
+			"Official example references Procedure in reasonReference, but the base R4 DeviceUseStatement constraint excludes Procedure.",
+		],
+		[
+			"MedicationRequest/medicationrequest0301.json",
+			"Official example uses Practitioner for dispenseRequest.performer, but the base R4 MedicationRequest constraint allows only Organization.",
+		],
+		[
+			"Observation/observation-example-clinical-gender.json",
+			"Official example uses Encounter as performer, but the base R4 Observation performer targets exclude Encounter.",
+		],
+	]),
+	r4b: new Map([
+		[
+			"DeviceMetric/devicemetric-example.json",
+			"Official example references DeviceDefinition in parent, but the base R4B DeviceMetric constraint allows only Device.",
+		],
+		[
+			"EvidenceVariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.json",
+			"Official example references Evidence in characteristic.definitionReference, but the base R4B EvidenceVariable constraint allows only EvidenceVariable or Group.",
+		],
+		[
+			"Observation/observation-example-clinical-gender.json",
+			"Official example uses Encounter as performer, but the base R4B Observation performer targets exclude Encounter.",
+		],
+		[
+			"StructureDefinition/structuredefinition-example-composition.json",
+			"Official example contains differential element IDs that do not match the base R4B id primitive regex.",
+		],
+		[
+			"StructureDefinition/structuredefinition-example-section-library.json",
+			"Official example contains differential element IDs that do not match the base R4B id primitive regex.",
+		],
+	]),
+	r5: new Map([
+		[
+			"BiologicallyDerivedProduct/biologicallyderivedproduct-example-allogeneicHCT.json",
+			"Official example references BiologicallyDerivedProduct in request, but the base R5 constraint allows only ServiceRequest.",
+		],
+		[
+			"BiologicallyDerivedProduct/biologicallyderivedproduct-example-autologousHCT.json",
+			"Official example references BiologicallyDerivedProduct in request, but the base R5 constraint allows only ServiceRequest.",
+		],
+		[
+			"DocumentReference/documentreference-example-xray.json",
+			"Official example references DocumentReference in context, but the base R5 constraint allows only Appointment, Encounter, or EpisodeOfCare.",
+		],
+		[
+			"Encounter/encounter-example.json",
+			"Official example references Encounter in careTeam, but the base R5 constraint allows only CareTeam.",
+		],
+		[
+			"QuestionnaireResponse/questionnaireresponse-example-f201-lifelines.json",
+			"Official example omits questionnaire, but the base R5 QuestionnaireResponse definition requires it.",
+		],
+		[
+			"Transport/transport-example.json",
+			"Official example references Transport in locations, but the base R5 constraint allows only Location.",
+		],
+	]),
+};
+
+const suites = [
+	{
+		fixturesRoot: resolve(process.cwd(), "tests", "fixtures", "stu3"),
+		label: "STU3",
+		expectedFailures: expectedFailureGroups.stu3,
+		schemas: stu3Schemas,
+	},
+	{
+		fixturesRoot: resolve(process.cwd(), "tests", "fixtures", "r4"),
+		label: "R4",
+		expectedFailures: expectedFailureGroups.r4,
+		schemas: r4Schemas,
+	},
+	{
+		fixturesRoot: resolve(process.cwd(), "tests", "fixtures", "r4b"),
+		label: "R4B",
+		expectedFailures: expectedFailureGroups.r4b,
+		schemas: r4bSchemas,
+	},
+	{
+		fixturesRoot: resolve(process.cwd(), "tests", "fixtures", "r5"),
+		label: "R5",
+		expectedFailures: expectedFailureGroups.r5,
+		schemas: r5Schemas,
+	},
+];
+
+const failures = [];
+let parsedCount = 0;
+let expectedFailureCount = 0;
+
+for (const suite of suites) {
+	const resourceDirs = readdirSync(suite.fixturesRoot, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.sort((left, right) => left.name.localeCompare(right.name));
+
+	for (const resourceEntry of resourceDirs) {
+		const resourceDir = join(suite.fixturesRoot, resourceEntry.name);
+		const entries = readdirSync(resourceDir, { withFileTypes: true });
+
+		for (const entry of entries.sort((left, right) =>
+			left.name.localeCompare(right.name),
+		)) {
+			if (!entry.isFile() || !entry.name.endsWith(".json")) {
+				continue;
+			}
+
+			const fixturePath = join(resourceDir, entry.name);
+			const fixtureKey = relative(suite.fixturesRoot, fixturePath);
+			const expectedFailure = suite.expectedFailures.get(fixtureKey);
+			const input = JSON.parse(readFileSync(fixturePath, "utf8"));
+			const result = validateResourcePayload(input, fixtureKey, suite.schemas);
+
+			if (expectedFailure) {
+				if (result.success) {
+					failures.push(
+						`${suite.label} ${fixtureKey} parsed successfully but is still listed as an expected failure: ${expectedFailure}`,
+					);
+				} else {
+					expectedFailureCount += 1;
+				}
+
+				continue;
+			}
+
+			if (!result.success) {
+				failures.push(
+					`${suite.label} ${fixtureKey} failed unexpectedly:\n${formatError(
+						result.error,
+					)}`,
+				);
+				continue;
+			}
+
+			parsedCount += 1;
+		}
+	}
+}
+
+if (failures.length > 0) {
+	throw new Error(failures.join("\n\n"));
+}
+
+console.log(
+	`Runtime official examples passed: ${parsedCount} parsed, ${expectedFailureCount} expected failures`,
+);
+
+function validateResourcePayload(input, fixtureLabel, schemas) {
+	if (!isRecord(input) || typeof input.resourceType !== "string") {
+		return {
+			success: false,
+			error: new Error(`${fixtureLabel} is missing a resourceType.`),
+		};
+	}
+
+	if (input.resourceType === "Bundle") {
+		if (
+			"entry" in input &&
+			input.entry !== undefined &&
+			!Array.isArray(input.entry)
+		) {
+			return {
+				success: false,
+				error: new Error(`${fixtureLabel} bundle is missing entry[].`),
+			};
+		}
+
+		const bundleEntries = Array.isArray(input.entry) ? input.entry : [];
+
+		for (const [index, entry] of bundleEntries.entries()) {
+			if (!isRecord(entry)) {
+				return {
+					success: false,
+					error: new Error(`${fixtureLabel} bundle entry ${index} is invalid.`),
+				};
+			}
+
+			if (!("resource" in entry) || entry.resource === undefined) {
+				continue;
+			}
+
+			const result = validateResourcePayload(
+				entry.resource,
+				`${fixtureLabel}#entry[${index}]`,
+				schemas,
+			);
+
+			if (!result.success) {
+				return result;
+			}
+		}
+	}
+
+	const schema = schemas[`${input.resourceType}Schema`];
+
+	if (!schema || typeof schema.safeParse !== "function") {
+		return {
+			success: false,
+			error: new Error(
+				`${fixtureLabel} uses ${input.resourceType}, but no exported schema was found.`,
+			),
+		};
+	}
+
+	return schema.safeParse(input);
+}
+
+function isRecord(value) {
+	return typeof value === "object" && value !== null;
+}
+
+function formatError(error) {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return JSON.stringify(error, null, 2);
+}

--- a/tests/runtime-smoke.mjs
+++ b/tests/runtime-smoke.mjs
@@ -1,0 +1,108 @@
+import { configureFhirString } from "fhir-zod";
+
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+function assertParseSuccess(schema, input, label) {
+	const result = schema.safeParse(input);
+	assert(result.success, `${label} should parse`);
+	return result.data;
+}
+
+function assertParseFailure(schema, input, label) {
+	const result = schema.safeParse(input);
+	assert(!result.success, `${label} should fail`);
+}
+
+assert(
+	typeof configureFhirString === "function",
+	"root package should export configureFhirString",
+);
+
+configureFhirString({ allowEmpty: true });
+
+const {
+	BundleSchema: R4BundleSchema,
+	HumanNameSchema: R4HumanNameSchema,
+	ObservationSchema: R4ObservationSchema,
+	PatientSchema: R4PatientSchema,
+} = await import("fhir-zod/r4");
+const { PatientSchema: R4BPatientSchema } = await import("fhir-zod/r4b");
+const { PatientSchema: R5PatientSchema } = await import("fhir-zod/r5");
+const { PatientSchema: STU3PatientSchema } = await import("fhir-zod/stu3");
+
+assertParseSuccess(
+	R4HumanNameSchema,
+	{ family: "" },
+	"R4 HumanName should allow an empty string after configuration",
+);
+
+const patient = assertParseSuccess(
+	R4PatientSchema,
+	{
+		resourceType: "Patient",
+		id: "runtime-smoke",
+		active: true,
+		name: [{ family: "Lovelace", given: ["Ada"] }],
+	},
+	"R4 Patient",
+);
+
+assert(
+	patient.resourceType === "Patient",
+	"R4 Patient should keep resourceType",
+);
+
+assertParseSuccess(
+	R4ObservationSchema,
+	{
+		resourceType: "Observation",
+		status: "final",
+		code: { text: "Runtime smoke" },
+		subject: { reference: "Patient/runtime-smoke" },
+		valueString: "ok",
+	},
+	"R4 Observation with one value[x]",
+);
+
+assertParseFailure(
+	R4ObservationSchema,
+	{
+		resourceType: "Observation",
+		status: "final",
+		code: { text: "Runtime smoke" },
+		valueString: "ok",
+		valueBoolean: true,
+	},
+	"R4 Observation with multiple value[x] fields",
+);
+
+assertParseSuccess(
+	R4BundleSchema,
+	{
+		resourceType: "Bundle",
+		type: "collection",
+		entry: [{ resource: patient }],
+	},
+	"R4 Bundle",
+);
+
+for (const [label, schema] of [
+	["STU3", STU3PatientSchema],
+	["R4B", R4BPatientSchema],
+	["R5", R5PatientSchema],
+]) {
+	assertParseSuccess(
+		schema,
+		{
+			resourceType: "Patient",
+			id: `runtime-smoke-${label.toLowerCase()}`,
+		},
+		`${label} Patient`,
+	);
+}
+
+console.log("Runtime smoke test passed");


### PR DESCRIPTION
# Summary

Adds Bun and Deno runtime compatibility coverage for the published ESM library surface. Closes #31.

## Changes

- Adds a weekly/manual Runtime Compatibility workflow that installs the packed package in a fresh consumer project and runs Bun/Deno with Zod 3.25.1 and Zod 4.
- Adds runtime scripts for public-import smoke checks and committed official example fixture parsing.
- Documents Node, Bun, and Deno runtime usage plus the runtime testing strategy.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run test:runtime
npm test -- tests/stu3-official-examples.test.ts tests/r4-official-examples.test.ts tests/r4b-official-examples.test.ts tests/r5-official-examples.test.ts tests/official-example-expected-failures.test.ts
npx biome check tests/runtime-smoke.mjs tests/runtime-official-examples.mjs .github/workflows/runtime-compat.yml package.json CONTRIBUTING.md
```

Also verified the packed-package runtime scripts locally with Bun + Zod 4 and Deno 2.5.4 with Zod 3.25.1 and Zod 4.

## Docs

- [ ] No docs update needed
- [x] Docs updated
