### PR TITLE
Fix runtime consumer directory

### DIFF
--- a/.github/workflows/runtime-compat.yml
+++ b/.github/workflows/runtime-compat.yml
@@ -50,28 +50,28 @@ jobs:
 
       - name: Pack package
         run: |
-          mkdir -p .runtime-consumer/tests
-          npm pack --ignore-scripts --pack-destination .runtime-consumer
-          cp tests/runtime-smoke.mjs .runtime-consumer/runtime-smoke.mjs
-          cp tests/runtime-official-examples.mjs .runtime-consumer/runtime-official-examples.mjs
-          cp -R tests/fixtures .runtime-consumer/tests/fixtures
+          mkdir -p runtime-consumer/tests
+          npm pack --ignore-scripts --pack-destination runtime-consumer
+          cp tests/runtime-smoke.mjs runtime-consumer/runtime-smoke.mjs
+          cp tests/runtime-official-examples.mjs runtime-consumer/runtime-official-examples.mjs
+          cp -R tests/fixtures runtime-consumer/tests/fixtures
 
       - name: Install packed package in consumer project
-        working-directory: .runtime-consumer
+        working-directory: runtime-consumer
         run: |
           npm init -y
           npm install --package-lock=false ./fhir-zod-*.tgz zod@${{ matrix.zod-version }}
 
-      - name: Run Bun smoke test
+      - name: Run Bun runtime compatibility checks
         if: ${{ matrix.runtime == 'bun' }}
-        working-directory: .runtime-consumer
+        working-directory: runtime-consumer
         run: |
           bun run runtime-smoke.mjs
           bun run runtime-official-examples.mjs
 
-      - name: Run Deno smoke test
+      - name: Run Deno runtime compatibility checks
         if: ${{ matrix.runtime == 'deno' }}
-        working-directory: .runtime-consumer
+        working-directory: runtime-consumer
         run: |
           deno run --node-modules-dir=manual --allow-read runtime-smoke.mjs
           deno run --node-modules-dir=manual --allow-read runtime-official-examples.mjs


### PR DESCRIPTION
# Summary

Fix the Runtime Compatibility workflow so the temporary consumer project uses a valid npm package directory name. The workflow now creates `runtime-consumer` instead of `.runtime-consumer`, allowing `npm init -y` to proceed before Bun and Deno smoke tests run.

## Changes

- Rename the workflow consumer directory from `.runtime-consumer` to `runtime-consumer`.
- Update the pack, fixture copy, install, Bun, and Deno workflow steps to use the renamed directory.
- No generated FHIR output, package exports, dependency lockfiles, or runtime scripts changed.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

List the commands you ran:

```bash
npx biome check .github/workflows/runtime-compat.yml
npm run test:runtime

# Zod 4 consumer reproduction:
check_dir=".context/runtime-consumer-check-$(date +%Y%m%d%H%M%S)"
mkdir -p "$check_dir/tests"
npm pack --ignore-scripts --pack-destination "$check_dir"
cp tests/runtime-smoke.mjs "$check_dir/runtime-smoke.mjs"
cp tests/runtime-official-examples.mjs "$check_dir/runtime-official-examples.mjs"
cp -R tests/fixtures "$check_dir/tests/fixtures"
cd "$check_dir"
npm init -y
npm install --package-lock=false ./fhir-zod-*.tgz zod@4
bun run runtime-smoke.mjs
bun run runtime-official-examples.mjs
deno run --node-modules-dir=manual --allow-read runtime-smoke.mjs
deno run --node-modules-dir=manual --allow-read runtime-official-examples.mjs
```

`npm run test:runtime` passed with `2980 parsed, 15 expected failures`.

The Zod 4 consumer reproduction passed through `npm init -y`, install, Bun, and Deno. Both official example runs reported `2980 parsed, 15 expected failures`.

`npx biome check .github/workflows/runtime-compat.yml` did not process the file because the repo's Biome config ignores `.github/workflows/runtime-compat.yml`.

## Docs

- [x] No docs update needed
- [ ] Docs updated
