### PR TITLE
Increase schema generator coverage

### DIFF
--- a/src/generator/sources/structuredefinition.ts
+++ b/src/generator/sources/structuredefinition.ts
@@ -122,6 +122,7 @@ export type StructureDefinitionBuildResult = {
 };
 
 type StructureDefinitionBuildOptions = {
+	packageRoot?: string;
 	release: FhirRelease;
 	scopeNames: Iterable<string>;
 };
@@ -144,7 +145,8 @@ const fhirPathPrimitiveByCode = new Map<string, string>([
 export function buildStructureDefinitionsFromSpec(
 	options: StructureDefinitionBuildOptions,
 ): StructureDefinitionBuildResult {
-	const packageRoot = resolveRequiredSpecPackageRoot(options.release.id);
+	const packageRoot =
+		options.packageRoot ?? resolveRequiredSpecPackageRoot(options.release.id);
 	const index = loadStructureDefinitionIndex(packageRoot);
 	const terminology = loadTerminologyIndex(packageRoot);
 	const primitivePatterns = loadPrimitivePatterns(index);

--- a/tests/generator-versions.test.ts
+++ b/tests/generator-versions.test.ts
@@ -1,5 +1,15 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import type {
+	NormalizedDefinition,
+	NormalizedProperty,
+} from "../src/generator/model.ts";
+import type { StructureDefinitionBuildResult } from "../src/generator/sources/structuredefinition.ts";
 import {
+	FhirRelease,
+	type FhirVersionId,
 	getFhirRelease,
 	R4BRelease,
 	R4Release,
@@ -50,6 +60,61 @@ const syntheticEntries: TargetEntry[] = [
 		url: null,
 	},
 ];
+
+const resourceTypeProperty: NormalizedProperty = {
+	binding: null,
+	choiceGroup: null,
+	choiceVariant: null,
+	description: "This is a Patient resource.",
+	enumValues: null,
+	fhirPath: "Patient.resourceType",
+	invariants: [],
+	isArray: false,
+	jsonName: "resourceType",
+	max: "1",
+	min: 1,
+	primitiveType: null,
+	required: true,
+	targetProfiles: [],
+	typeRef: null,
+};
+
+const patientDefinition: NormalizedDefinition = {
+	baseName: null,
+	description: "Synthetic Patient",
+	kind: "resource",
+	name: "Patient",
+	notes: [],
+	properties: [resourceTypeProperty],
+	resourceTypeLiteral: "Patient",
+	sourceMetadata: {
+		profileUrl: "http://hl7.org/fhir/StructureDefinition/Patient",
+		releaseLabel: "R4",
+		version: "4.0.1-test",
+	},
+};
+
+class SyntheticGenerationRelease extends FhirRelease {
+	readonly abstractTargetNames = ["Element"] as const;
+	readonly id: FhirVersionId = "r4";
+	readonly label = "R4";
+	readonly capturedScopes: string[][] = [];
+
+	loadTargetEntries(): TargetEntry[] {
+		return syntheticEntries;
+	}
+
+	buildDefinitions(
+		scopeNames: Iterable<string> = this.listGenerationTargetNames(),
+	): StructureDefinitionBuildResult {
+		this.capturedScopes.push([...scopeNames]);
+
+		return {
+			definitions: new Map([["Patient", patientDefinition]]),
+			primitivePatterns: new Map(),
+		};
+	}
+}
 
 describe("FHIR version registry", () => {
 	it("returns all supported releases and null for unknown versions", () => {
@@ -104,5 +169,46 @@ describe("FHIR version registry", () => {
 			generationTargetCount: 2,
 			profileResourceCount: 1,
 		});
+	});
+
+	it("selects generation targets from core resources and abstract whitelist", () => {
+		const release = new SyntheticGenerationRelease();
+
+		expect(release.listCoreResourceNames()).toEqual(["Patient"]);
+		expect(release.listGenerationTargetNames()).toEqual(["Element", "Patient"]);
+	});
+
+	it("generates version output into a requested directory", () => {
+		const release = new SyntheticGenerationRelease();
+		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-version-generate-"));
+
+		const result = release.generate({
+			generatedAt: "2026-04-16T00:00:00.000Z",
+			outputDir,
+			prune: true,
+		});
+
+		expect(release.capturedScopes).toEqual([["Element", "Patient"]]);
+		expect(result.files.map((file) => file.split("/").at(-1)).sort()).toEqual([
+			"Patient.ts",
+			"index.ts",
+		]);
+		expect(readFileSync(join(outputDir, "Patient.ts"), "utf8")).toContain(
+			"export const PatientSchema",
+		);
+	});
+
+	it("passes explicit generation scopes to definition building", () => {
+		const release = new SyntheticGenerationRelease();
+		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-version-generate-"));
+
+		release.generate({
+			generatedAt: "2026-04-16T00:00:00.000Z",
+			outputDir,
+			prune: false,
+			scopeNames: ["Patient"],
+		});
+
+		expect(release.capturedScopes).toEqual([["Patient"]]);
 	});
 });

--- a/tests/helpers/synthetic-spec-package.ts
+++ b/tests/helpers/synthetic-spec-package.ts
@@ -1,0 +1,402 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type JsonResource = {
+	[key: string]: unknown;
+	name?: string;
+	resourceType: string;
+	url?: string;
+};
+
+type SyntheticSpecPackage = {
+	packageRoot: string;
+	writeCodeSystem: (resource: JsonResource) => void;
+	writeStructureDefinition: (resource: JsonResource) => void;
+	writeValueSet: (resource: JsonResource) => void;
+};
+
+function writeJsonResource(
+	packageRoot: string,
+	filename: string,
+	value: unknown,
+): void {
+	writeFileSync(
+		join(packageRoot, filename),
+		`${JSON.stringify(value, null, 2)}\n`,
+		"utf8",
+	);
+}
+
+function resourceFilename(prefix: string, resource: JsonResource): string {
+	const id = resource.name ?? resource.url?.split("/").at(-1);
+
+	if (!id) {
+		throw new Error(`Synthetic ${prefix} resource requires a name or url.`);
+	}
+
+	return `${prefix}-${id}.json`;
+}
+
+export function createSyntheticSpecPackage(): SyntheticSpecPackage {
+	const packageRoot = mkdtempSync(join(tmpdir(), "fhir-zod-spec-package-"));
+	mkdirSync(packageRoot, { recursive: true });
+
+	const packageApi: SyntheticSpecPackage = {
+		packageRoot,
+		writeCodeSystem: (resource) => {
+			writeJsonResource(
+				packageRoot,
+				resourceFilename("CodeSystem", resource),
+				resource,
+			);
+		},
+		writeStructureDefinition: (resource) => {
+			writeJsonResource(
+				packageRoot,
+				resourceFilename("StructureDefinition", resource),
+				resource,
+			);
+		},
+		writeValueSet: (resource) => {
+			writeJsonResource(
+				packageRoot,
+				resourceFilename("ValueSet", resource),
+				resource,
+			);
+		},
+	};
+
+	writeBaseStructureDefinitions(packageApi);
+	writeTerminology(packageApi);
+	writeSchemaResourceDefinitions(packageApi);
+
+	writeJsonResource(packageRoot, "Parameters-ignored.json", {
+		resourceType: "Parameters",
+	});
+
+	return packageApi;
+}
+
+function structureDefinition(
+	name: string,
+	options: {
+		abstract?: boolean;
+		baseDefinition?: string;
+		description?: string;
+		elements?: unknown[];
+		kind: string;
+		type?: string;
+		url?: string;
+		version?: string;
+	},
+): JsonResource {
+	const type = options.type ?? name;
+
+	return {
+		abstract: options.abstract,
+		baseDefinition: options.baseDefinition,
+		description: options.description ?? `${name} definition`,
+		kind: options.kind,
+		name,
+		resourceType: "StructureDefinition",
+		snapshot: {
+			element: [
+				element(type, {
+					definition: `${name} root`,
+					max: "1",
+					min: 0,
+				}),
+				...(options.elements ?? []),
+			],
+		},
+		type,
+		url: options.url ?? `http://hl7.org/fhir/StructureDefinition/${name}`,
+		version: options.version ?? "4.0.1-test",
+	};
+}
+
+function element(
+	path: string,
+	options: {
+		basePath?: string;
+		binding?: unknown;
+		constraint?: unknown[];
+		definition?: string;
+		max?: string;
+		min?: number;
+		short?: string;
+		type?: unknown[];
+	} = {},
+): unknown {
+	return {
+		...(options.basePath ? { base: { path: options.basePath } } : {}),
+		...(options.binding ? { binding: options.binding } : {}),
+		...(options.constraint ? { constraint: options.constraint } : {}),
+		...(options.definition ? { definition: options.definition } : {}),
+		id: path,
+		max: options.max ?? "1",
+		min: options.min ?? 0,
+		path,
+		...(options.short ? { short: options.short } : {}),
+		...(options.type ? { type: options.type } : {}),
+	};
+}
+
+function type(
+	code: string,
+	options: {
+		extension?: unknown[];
+		targetProfile?: string | string[];
+	} = {},
+): unknown {
+	return {
+		code,
+		...(options.extension ? { extension: options.extension } : {}),
+		...(options.targetProfile ? { targetProfile: options.targetProfile } : {}),
+	};
+}
+
+function writeBaseStructureDefinitions(spec: SyntheticSpecPackage): void {
+	spec.writeStructureDefinition(
+		structureDefinition("Element", {
+			abstract: true,
+			elements: [
+				element("Element.id", {
+					type: [type("http://hl7.org/fhirpath/System.String")],
+				}),
+			],
+			kind: "complex-type",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("BackboneElement", {
+			abstract: true,
+			baseDefinition: "http://hl7.org/fhir/StructureDefinition/Element",
+			kind: "complex-type",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("Resource", {
+			abstract: true,
+			elements: [
+				element("Resource.id", {
+					basePath: "Resource.id",
+					type: [type("http://hl7.org/fhirpath/System.String")],
+				}),
+			],
+			kind: "resource",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("DomainResource", {
+			abstract: true,
+			baseDefinition: "http://hl7.org/fhir/StructureDefinition/Resource",
+			kind: "resource",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("string", {
+			elements: [
+				element("string.value", {
+					type: [
+						type("http://hl7.org/fhirpath/System.String", {
+							extension: [
+								{
+									url: "http://hl7.org/fhir/StructureDefinition/regex",
+									valueString: "[A-Z]+",
+								},
+							],
+						}),
+					],
+				}),
+			],
+			kind: "primitive-type",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("code", {
+			elements: [
+				element("code.value", {
+					type: [type("http://hl7.org/fhirpath/System.String")],
+				}),
+			],
+			kind: "primitive-type",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("CodeableConcept", {
+			elements: [
+				element("CodeableConcept.text", {
+					type: [type("string")],
+				}),
+			],
+			kind: "complex-type",
+		}),
+	);
+	spec.writeStructureDefinition(
+		structureDefinition("Reference", {
+			elements: [
+				element("Reference.reference", {
+					type: [type("string")],
+				}),
+			],
+			kind: "complex-type",
+		}),
+	);
+}
+
+function writeTerminology(spec: SyntheticSpecPackage): void {
+	spec.writeCodeSystem({
+		concept: [
+			{ code: "system-code" },
+			{ code: "system-parent", concept: [{ code: "system-child" }] },
+		],
+		resourceType: "CodeSystem",
+		url: "http://example.test/CodeSystem/patient-status",
+	});
+	spec.writeValueSet({
+		compose: {
+			include: [
+				{
+					concept: [{ code: "inline-code" }],
+					system: "http://example.test/CodeSystem/patient-status",
+					valueSet: ["http://example.test/ValueSet/imported-status|2"],
+				},
+			],
+		},
+		expansion: {
+			contains: [
+				{
+					code: "expanded-code",
+					contains: [{ code: "nested-expanded-code" }],
+				},
+			],
+		},
+		resourceType: "ValueSet",
+		url: "http://example.test/ValueSet/patient-status",
+	});
+	spec.writeValueSet({
+		compose: {
+			include: [
+				{
+					concept: [{ code: "imported-code" }],
+					valueSet: ["http://example.test/ValueSet/patient-status"],
+				},
+			],
+		},
+		resourceType: "ValueSet",
+		url: "http://example.test/ValueSet/imported-status",
+	});
+}
+
+function writeSchemaResourceDefinitions(spec: SyntheticSpecPackage): void {
+	spec.writeStructureDefinition(
+		structureDefinition("Patient", {
+			baseDefinition: "http://hl7.org/fhir/StructureDefinition/DomainResource",
+			elements: [
+				element("Patient.id", {
+					basePath: "Resource.id",
+					definition: "Logical id",
+					type: [type("http://hl7.org/fhirpath/System.String")],
+				}),
+				element("Patient.name", {
+					definition: "Names",
+					max: "*",
+					type: [type("string")],
+				}),
+				element("Patient.status", {
+					binding: {
+						strength: "required",
+						valueSet: "http://example.test/ValueSet/patient-status|1",
+					},
+					definition: "Status",
+					min: 1,
+					type: [type("code")],
+				}),
+				element("Patient.language", {
+					binding: {
+						strength: "preferred",
+						valueSet: "http://example.test/ValueSet/patient-status",
+					},
+					type: [type("code")],
+				}),
+				element("Patient.managingOrganization", {
+					type: [
+						type("Reference", {
+							targetProfile: [
+								"http://hl7.org/fhir/StructureDefinition/Organization",
+								"http://hl7.org/fhir/StructureDefinition/Patient",
+							],
+						}),
+					],
+				}),
+				element("Patient.contact", {
+					definition: "A contact",
+					type: [type("BackboneElement")],
+				}),
+				element("Patient.contact.name", {
+					min: 1,
+					type: [type("string")],
+				}),
+				element("Patient.contact.relationship", {
+					max: "*",
+					type: [type("CodeableConcept")],
+				}),
+				element("Patient.empty", {
+					type: [type("BackboneElement")],
+				}),
+			],
+			kind: "resource",
+			version: "4.0.1-patient",
+		}),
+	);
+
+	spec.writeStructureDefinition(
+		structureDefinition("Observation", {
+			baseDefinition: "http://hl7.org/fhir/StructureDefinition/DomainResource",
+			elements: [
+				element("Observation.status", {
+					binding: {
+						strength: "required",
+						valueSetReference: {
+							reference: "http://example.test/ValueSet/patient-status|1",
+						},
+					},
+					constraint: [
+						{
+							expression: "status.exists()",
+							human: "status exists",
+							key: "obs-2",
+							severity: "error",
+						},
+						{
+							key: "obs-1",
+						},
+						{
+							human: "missing key is ignored",
+						},
+					],
+					min: 1,
+					type: [type("code")],
+				}),
+				element("Observation.value[x]", {
+					type: [
+						type("string"),
+						type("CodeableConcept"),
+						type("Reference", {
+							targetProfile: "http://hl7.org/fhir/StructureDefinition/Patient",
+						}),
+						type("Reference", {
+							targetProfile: [
+								"http://hl7.org/fhir/StructureDefinition/Encounter",
+								"http://hl7.org/fhir/StructureDefinition/Patient",
+							],
+						}),
+					],
+				}),
+			],
+			kind: "resource",
+		}),
+	);
+}

--- a/tests/structuredefinition-normalizer.test.ts
+++ b/tests/structuredefinition-normalizer.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import type {
+	NormalizedDefinition,
+	NormalizedProperty,
+} from "../src/generator/model.ts";
+import { buildStructureDefinitionsFromSpec } from "../src/generator/sources/structuredefinition.ts";
+import { R4Release } from "../src/generator/versions.ts";
+import { createSyntheticSpecPackage } from "./helpers/synthetic-spec-package.ts";
+
+function buildSyntheticDefinitions(scopeNames: string[]) {
+	const spec = createSyntheticSpecPackage();
+
+	return buildStructureDefinitionsFromSpec({
+		packageRoot: spec.packageRoot,
+		release: new R4Release(),
+		scopeNames,
+	});
+}
+
+function requireDefinition(
+	definitions: Map<string, NormalizedDefinition>,
+	name: string,
+): NormalizedDefinition {
+	const definition = definitions.get(name);
+
+	if (!definition) {
+		throw new Error(`Expected ${name} to be normalized.`);
+	}
+
+	return definition;
+}
+
+function requireProperty(
+	definition: NormalizedDefinition,
+	jsonName: string,
+): NormalizedProperty {
+	const property = definition.properties.find(
+		(candidate) => candidate.jsonName === jsonName,
+	);
+
+	if (!property) {
+		throw new Error(`Expected ${definition.name}.${jsonName} property.`);
+	}
+
+	return property;
+}
+
+describe("StructureDefinition source normalizer", () => {
+	it("builds root schema model inputs and expands schema dependencies", () => {
+		const { definitions } = buildSyntheticDefinitions(["Patient"]);
+		const patient = requireDefinition(definitions, "Patient");
+
+		expect(patient).toMatchObject({
+			baseName: "DomainResource",
+			kind: "resource",
+			resourceTypeLiteral: "Patient",
+			sourceMetadata: {
+				profileUrl: "http://hl7.org/fhir/StructureDefinition/Patient",
+				releaseLabel: "R4",
+				version: "4.0.1-patient",
+			},
+		});
+		expect(requireProperty(patient, "resourceType")).toMatchObject({
+			jsonName: "resourceType",
+			required: true,
+			typeRef: null,
+		});
+
+		expect([...definitions.keys()].sort()).toEqual(
+			expect.arrayContaining([
+				"BackboneElement",
+				"CodeableConcept",
+				"DomainResource",
+				"Patient",
+				"Patient_Contact",
+				"Reference",
+				"Resource",
+			]),
+		);
+
+		const contact = requireDefinition(definitions, "Patient_Contact");
+		expect(contact).toMatchObject({
+			baseName: "BackboneElement",
+			description: "A contact",
+			kind: "backbone",
+			resourceTypeLiteral: null,
+		});
+		expect(requireProperty(contact, "name")).toMatchObject({
+			jsonName: "name",
+			primitiveType: "string",
+			required: true,
+		});
+		expect(requireProperty(contact, "relationship")).toMatchObject({
+			isArray: true,
+			jsonName: "relationship",
+			typeRef: "CodeableConcept",
+		});
+	});
+
+	it("models primitive companions and primitive regex metadata", () => {
+		const { definitions, primitivePatterns } = buildSyntheticDefinitions([
+			"Patient",
+		]);
+		const patient = requireDefinition(definitions, "Patient");
+
+		expect(primitivePatterns.get("string")).toBe("[A-Z]+");
+		expect(requireProperty(patient, "id")).toMatchObject({
+			jsonName: "id",
+			primitiveType: "id",
+		});
+		expect(requireProperty(patient, "_id")).toMatchObject({
+			jsonName: "_id",
+			isArray: false,
+			typeRef: "Element",
+		});
+		expect(requireProperty(patient, "name")).toMatchObject({
+			isArray: true,
+			jsonName: "name",
+			primitiveType: "string",
+		});
+		expect(requireProperty(patient, "_name")).toMatchObject({
+			isArray: true,
+			jsonName: "_name",
+			typeRef: "Element",
+		});
+	});
+
+	it("normalizes choices and constrained references", () => {
+		const { definitions } = buildSyntheticDefinitions(["Observation"]);
+		const observation = requireDefinition(definitions, "Observation");
+
+		expect(requireProperty(observation, "valueString")).toMatchObject({
+			choiceGroup: "value[x]",
+			choiceVariant: "string",
+			primitiveType: "string",
+		});
+		expect(requireProperty(observation, "_valueString")).toMatchObject({
+			choiceGroup: "value[x]",
+			choiceVariant: "string",
+			typeRef: "Element",
+		});
+		expect(requireProperty(observation, "valueCodeableConcept")).toMatchObject({
+			choiceGroup: "value[x]",
+			choiceVariant: "CodeableConcept",
+			typeRef: "CodeableConcept",
+		});
+		expect(requireProperty(observation, "valueReference")).toMatchObject({
+			choiceGroup: "value[x]",
+			choiceVariant: "Reference",
+			targetProfiles: [
+				"http://hl7.org/fhir/StructureDefinition/Encounter",
+				"http://hl7.org/fhir/StructureDefinition/Patient",
+			],
+			typeRef: "Reference",
+		});
+		expect(
+			observation.properties.filter(
+				(property) => property.jsonName === "valueReference",
+			),
+		).toHaveLength(1);
+	});
+
+	it("preserves constrained reference target profiles on normal fields", () => {
+		const { definitions } = buildSyntheticDefinitions(["Patient"]);
+		const patient = requireDefinition(definitions, "Patient");
+
+		expect(requireProperty(patient, "managingOrganization")).toMatchObject({
+			targetProfiles: [
+				"http://hl7.org/fhir/StructureDefinition/Organization",
+				"http://hl7.org/fhir/StructureDefinition/Patient",
+			],
+			typeRef: "Reference",
+		});
+	});
+
+	it("extracts required code enums from ValueSets and CodeSystems", () => {
+		const { definitions } = buildSyntheticDefinitions([
+			"Patient",
+			"Observation",
+		]);
+		const patientStatus = requireProperty(
+			requireDefinition(definitions, "Patient"),
+			"status",
+		);
+		const observationStatus = requireProperty(
+			requireDefinition(definitions, "Observation"),
+			"status",
+		);
+
+		expect(patientStatus.enumValues).toEqual([
+			"expanded-code",
+			"imported-code",
+			"inline-code",
+			"nested-expanded-code",
+			"system-child",
+			"system-code",
+			"system-parent",
+		]);
+		expect(observationStatus.enumValues).toEqual(patientStatus.enumValues);
+		expect(
+			requireProperty(requireDefinition(definitions, "Patient"), "language")
+				.enumValues,
+		).toBeNull();
+	});
+
+	it("preserves sorted invariants and fallback values", () => {
+		const { definitions } = buildSyntheticDefinitions(["Observation"]);
+		const status = requireProperty(
+			requireDefinition(definitions, "Observation"),
+			"status",
+		);
+
+		expect(status.invariants).toEqual([
+			{
+				expression: null,
+				human: "",
+				key: "obs-1",
+				severity: "",
+			},
+			{
+				expression: "status.exists()",
+				human: "status exists",
+				key: "obs-2",
+				severity: "error",
+			},
+		]);
+	});
+
+	it("skips missing schema inputs safely", () => {
+		const { definitions } = buildSyntheticDefinitions([
+			"Missing",
+			"Missing_Child",
+			"Patient_Missing",
+		]);
+
+		expect(definitions.size).toBe(0);
+	});
+});

--- a/tests/zod-emitter.test.ts
+++ b/tests/zod-emitter.test.ts
@@ -1,0 +1,197 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	buildRuntimeSchemas,
+	writeNormalizedZodDefinitions,
+} from "../src/generator/emit/zod.ts";
+import type { NormalizedDefinition } from "../src/generator/model.ts";
+import { buildStructureDefinitionsFromSpec } from "../src/generator/sources/structuredefinition.ts";
+import { R4Release } from "../src/generator/versions.ts";
+import { createSyntheticSpecPackage } from "./helpers/synthetic-spec-package.ts";
+
+function buildSyntheticSchemaInput(): {
+	definitions: Map<string, NormalizedDefinition>;
+	primitivePatterns: Map<string, string>;
+} {
+	const spec = createSyntheticSpecPackage();
+
+	return buildStructureDefinitionsFromSpec({
+		packageRoot: spec.packageRoot,
+		release: new R4Release(),
+		scopeNames: [
+			"Element",
+			"BackboneElement",
+			"Resource",
+			"DomainResource",
+			"CodeableConcept",
+			"Reference",
+			"Patient",
+			"Observation",
+		],
+	});
+}
+
+describe("Zod emitter", () => {
+	it("emits schema files, public models, choices, references, and inheritance", () => {
+		const { definitions, primitivePatterns } = buildSyntheticSchemaInput();
+		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-emitter-"));
+		const stalePath = join(outputDir, "Stale.ts");
+		writeFileSync(stalePath, "export const stale = true;\n", "utf8");
+
+		const files = writeNormalizedZodDefinitions({
+			definitions,
+			generatedAt: "2026-04-16T00:00:00.000Z",
+			outputDir,
+			primitivePatterns,
+			prune: true,
+		});
+
+		expect(files.map((file) => file.split("/").at(-1)).sort()).toEqual(
+			expect.arrayContaining([
+				"BackboneElement.ts",
+				"CodeableConcept.ts",
+				"DomainResource.ts",
+				"Element.ts",
+				"Observation.ts",
+				"Patient.ts",
+				"Patient_Contact.ts",
+				"Reference.ts",
+				"Resource.ts",
+				"index.ts",
+			]),
+		);
+		expect(existsSync(stalePath)).toBe(false);
+
+		const index = readFileSync(join(outputDir, "index.ts"), "utf8");
+		const patient = readFileSync(join(outputDir, "Patient.ts"), "utf8");
+		const observation = readFileSync(join(outputDir, "Observation.ts"), "utf8");
+		const contact = readFileSync(join(outputDir, "Patient_Contact.ts"), "utf8");
+
+		expect(index).toContain('export type { Patient } from "./Patient";');
+		expect(index).toContain('export { PatientSchema } from "./Patient";');
+		expect(patient).toContain(
+			"export interface Patient extends DomainResource",
+		);
+		expect(patient).toContain("export const PatientSchemaInternal");
+		expect(patient).toContain("export const PatientSchema =");
+		expect(patient).toContain("name?: Array<string | null>;");
+		expect(patient).toContain("_name?: Array<Element | null>;");
+		expect(patient).toContain("validatePrimitiveArrayPair");
+		expect(patient).toContain("validateReferenceTarget");
+		expect(patient).toContain(
+			'"http://hl7.org/fhir/StructureDefinition/Organization"',
+		);
+		expect(patient).toContain(
+			'"http://hl7.org/fhir/StructureDefinition/Patient"',
+		);
+		expect(patient).toContain('"Organization"');
+
+		expect(observation).toContain("valueString?: string;");
+		expect(observation).toContain("_valueString?: Element;");
+		expect(observation).toContain("valueCodeableConcept?: CodeableConcept;");
+		expect(observation).toContain("valueReference?: Reference;");
+		expect(observation).toContain("Only one of valueCodeableConcept");
+		expect(observation).toContain("validateReferenceTarget");
+		expect(observation).toContain('"Encounter"');
+
+		expect(contact).toContain(
+			"export interface Patient_Contact extends BackboneElement",
+		);
+		expect(contact).toContain("BackboneElementSchemaInternal.extend");
+	});
+
+	it("falls back to flattened schemas when runtime inheritance would cycle", () => {
+		const { definitions, primitivePatterns } = buildSyntheticSchemaInput();
+		const outputDir = mkdtempSync(join(tmpdir(), "fhir-zod-emitter-cycle-"));
+		const patient = definitions.get("Patient");
+		const domainResource = definitions.get("DomainResource");
+
+		if (!patient || !domainResource) {
+			throw new Error(
+				"Synthetic definitions did not include Patient base graph.",
+			);
+		}
+
+		definitions.set("DomainResource", {
+			...domainResource,
+			properties: [
+				...domainResource.properties,
+				{
+					binding: null,
+					choiceGroup: null,
+					choiceVariant: null,
+					description: "Cycle back to Patient",
+					enumValues: null,
+					fhirPath: "DomainResource.containedPatient",
+					invariants: [],
+					isArray: false,
+					jsonName: "containedPatient",
+					max: "1",
+					min: 0,
+					primitiveType: null,
+					required: false,
+					targetProfiles: [],
+					typeRef: "Patient",
+				},
+			],
+		});
+
+		writeNormalizedZodDefinitions({
+			definitions,
+			generatedAt: "2026-04-16T00:00:00.000Z",
+			outputDir,
+			primitivePatterns,
+			prune: true,
+		});
+
+		const patientContent = readFileSync(join(outputDir, "Patient.ts"), "utf8");
+		expect(patientContent).toContain(
+			"export interface Patient extends DomainResource",
+		);
+		expect(patientContent).toContain("export const PatientSchemaInternal = z");
+		expect(patientContent).not.toContain(
+			"PatientSchemaInternal = DomainResourceSchemaInternal.extend",
+		);
+	});
+
+	it("builds runtime schemas that enforce schema semantics", () => {
+		const { definitions, primitivePatterns } = buildSyntheticSchemaInput();
+		const schemas = buildRuntimeSchemas(definitions, primitivePatterns);
+
+		expect(
+			schemas.Patient.safeParse({
+				managingOrganization: {
+					reference: "Organization/example",
+				},
+				name: ["ALICE"],
+				resourceType: "Patient",
+				status: "inline-code",
+			}).success,
+		).toBe(true);
+		expect(
+			schemas.Patient.safeParse({
+				managingOrganization: {
+					reference: "Device/example",
+				},
+				resourceType: "Patient",
+				status: "inline-code",
+			}).success,
+		).toBe(false);
+		expect(
+			schemas.Observation.safeParse({
+				resourceType: "Observation",
+				status: "system-child",
+				valueCodeableConcept: {},
+				valueString: "abc",
+			}).success,
+		).toBe(false);
+		expect(
+			schemas.Patient.safeParse({
+				resourceType: "Patient",
+				status: "not-allowed",
+			}).success,
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
# Summary

Closes #23. Adds schema-focused coverage for the StructureDefinition normalizer, Zod emitter, runtime schema behavior, and generation-scope registry paths using deterministic synthetic FHIR spec fixtures.

## Changes

- Add an internal `packageRoot` option to `buildStructureDefinitionsFromSpec` so tests can exercise schema normalization without relying on `.local/spec-cache`.
- Add synthetic spec fixture helpers plus tests for dependency expansion, backbone definitions, primitive companions, choice fields, constrained references, required code enums, invariants, emitted schema files, runtime validation, inheritance, cycle flattening, and stale-file pruning.
- No generated `src/<version>/` output changed.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm test -- tests/structuredefinition-normalizer.test.ts tests/zod-emitter.test.ts tests/generator-versions.test.ts
npm test
npm run typecheck
npm run check
npm run coverage
```

Coverage with local spec artifacts present: 92.72% statements overall; `structuredefinition.ts` 96.49%, `emit/zod.ts` 94.68%, and `versions.ts` 100%.

## Docs

- [x] No docs update needed
- [ ] Docs updated

_Created with Codex._
