### PR TITLE
Defer FHIR string config to parse time

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ import { PatientSchema, type Patient } from "fhir-zod/r4/Patient"
 
 ## Handling empty FHIR strings
 
-FHIR `string` values reject empty strings by default. To accept real-world payloads that use empty strings for the FHIR `string` primitive, configure the root package before constructing or importing schemas that use `fhirString()`:
+FHIR `string` values reject empty strings by default. To accept real-world payloads that use empty strings for the FHIR `string` primitive, configure the root package before parsing:
 
 ```ts
 import { configureFhirString } from "fhir-zod"
@@ -189,7 +189,15 @@ import { configureFhirString } from "fhir-zod"
 configureFhirString({ allowEmpty: true })
 ```
 
-This affects all generated schemas. It only changes the FHIR `string` primitive. Other primitives such as `date`, `dateTime`, `base64Binary`, `code`, `id`, and `uri` keep their default validation behavior.
+This setting is process-global and is read when schemas parse input, so it can be applied before or after generated schema modules are imported. It affects all generated schemas that validate FHIR `string` values. It only changes the FHIR `string` primitive. Other primitives such as `date`, `dateTime`, `base64Binary`, `code`, `id`, and `uri` keep their default validation behavior.
+
+Test suites that change this setting should reset it in `afterEach`:
+
+```ts
+afterEach(() => {
+  configureFhirString({ allowEmpty: false })
+})
+```
 
 ## Bundle size and imports
 

--- a/src/shared/fhir-primitives.ts
+++ b/src/shared/fhir-primitives.ts
@@ -77,8 +77,15 @@ export function fhirOid(): z.ZodString {
 	return withPattern(fhirOidPattern);
 }
 
-export function fhirString(): z.ZodString {
-	return withPattern(fhirStringPatternForConfiguration());
+export function fhirString() {
+	return z.string().superRefine((value, context) => {
+		if (!fhirStringPatternForConfiguration().test(value)) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Invalid FHIR string",
+			});
+		}
+	});
 }
 
 export function fhirTime(): z.ZodString {

--- a/tests/fhir-primitives.test.ts
+++ b/tests/fhir-primitives.test.ts
@@ -152,13 +152,35 @@ describe("FHIR primitives", () => {
 			expect(fhirString().safeParse("").success).toBe(false);
 		});
 
-		it("allows empty strings for newly constructed fhirString schemas after configuration", () => {
+		it("allows empty strings for fhirString schemas after configuration", () => {
 			const strictSchema = fhirString();
 
 			configureFhirString({ allowEmpty: true });
 
-			expect(strictSchema.safeParse("").success).toBe(false);
+			expect(strictSchema.safeParse("").success).toBe(true);
 			expect(fhirString().safeParse("").success).toBe(true);
+		});
+
+		it("allows empty strings when configured after generated schemas are imported", () => {
+			configureFhirString({ allowEmpty: true });
+
+			expect(r4Schemas.HumanNameSchema.safeParse({ family: "" }).success).toBe(
+				true,
+			);
+		});
+
+		it("applies the current global configuration at parse time", () => {
+			const schema = fhirString();
+
+			expect(schema.safeParse("").success).toBe(false);
+
+			configureFhirString({ allowEmpty: true });
+
+			expect(schema.safeParse("").success).toBe(true);
+
+			configureFhirString({ allowEmpty: false });
+
+			expect(schema.safeParse("").success).toBe(false);
 		});
 
 		it("does not allow empty strings for other primitives", () => {

--- a/tests/runtime-smoke.mjs
+++ b/tests/runtime-smoke.mjs
@@ -22,8 +22,6 @@ assert(
 	"root package should export configureFhirString",
 );
 
-configureFhirString({ allowEmpty: true });
-
 const { HumanNameSchema: R4HumanNameSchema } = await import("fhir-zod/r4");
 const { BundleSchema: R4BundleSchema } = await import("fhir-zod/r4/Bundle");
 const { ObservationSchema: R4ObservationSchema } = await import(
@@ -37,10 +35,12 @@ const { PatientSchema: STU3PatientSchema } = await import(
 	"fhir-zod/stu3/Patient"
 );
 
+configureFhirString({ allowEmpty: true });
+
 assertParseSuccess(
 	R4HumanNameSchema,
 	{ family: "" },
-	"R4 HumanName should allow an empty string after configuration",
+	"R4 HumanName should allow an empty string when configured after import",
 );
 
 assertParseSuccess(


### PR DESCRIPTION
# Summary

Closes #47. `configureFhirString({ allowEmpty: true })` now affects FHIR string validation at parse time, so generated schemas can be imported before configuration without locking in strict behavior.

## Changes

- Change `fhirString()` to use `superRefine` and read the current string configuration during parsing.
- Add tests for prebuilt primitive schemas, already-imported generated schemas, and runtime package imports.
- Update README guidance to describe process-global parse-time configuration and test reset expectations.

## API Or Breaking Changes

- [ ] No public API changes
- [x] Public API added or changed
- [ ] Breaking change

The exported API shape is unchanged, but the timing of `configureFhirString` behavior changes from schema construction time to parse time.

## Testing

```bash
npx vitest run tests/fhir-primitives.test.ts
npm run build
node tests/runtime-smoke.mjs
npm test
npx biome check README.md src/shared/fhir-primitives.ts tests/fhir-primitives.test.ts tests/runtime-smoke.mjs
```

All listed commands passed. `npm run check` was also attempted and is blocked by existing repo-wide Biome formatting diagnostics in generated files such as `src/r4/Account/Account.ts` plus an unrelated `tests/zod-emitter.test.ts` formatting diagnostic.

## Docs

- [ ] No docs update needed
- [x] Docs updated

_Created with Codex._
