### PR TITLE
Add VitePress docs with local search

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Compatible with [Zod](https://zod.dev/) 3.25.x and 4.x.x.
 
 Supports Node.js 20+ and modern bundlers. Import concrete resources from resource module entry points such as `fhir-zod/r4/Patient`. Versioned entry points such as `fhir-zod/r4` expose shared datatypes and supporting generated definitions.
 
+## Documentation
+
+The VitePress docs source for deeper package usage guidance lives in [`docs/`](./docs/). Preview it locally with:
+
+```bash
+npm run docs:dev
+```
+
 ## Quick start
 
 ```ts

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+	title: "fhir-zod",
+	description: "Zod schemas for FHIR resources",
+	themeConfig: {
+		search: {
+			provider: "local",
+		},
+		nav: [
+			{ text: "Introduction", link: "/" },
+			{ text: "Getting Started", link: "/getting-started" },
+		],
+		sidebar: [
+			{
+				text: "Introduction",
+				items: [
+					{ text: "Overview", link: "/" },
+					{ text: "Getting Started", link: "/getting-started" },
+					{ text: "FHIR Versions", link: "/versions" },
+					{ text: "API Conventions", link: "/api-conventions" },
+					{ text: "Validation Scope", link: "/validation-scope" },
+				],
+			},
+		],
+	},
+});

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -1,0 +1,62 @@
+---
+title: API Conventions
+description: Public naming rules and import conventions for generated FHIR models and Zod schemas.
+---
+
+# API Conventions
+
+The intended public shape is type-first:
+
+- `Patient` is the generated TypeScript model
+- `PatientSchema` is the runtime validator
+
+## Preferred import patterns
+
+Import concrete resources from resource entry points:
+
+```ts
+import { PatientSchema, type Patient } from "fhir-zod/r4/Patient";
+```
+
+Import shared datatypes from the version entry point when needed:
+
+```ts
+import { HumanNameSchema, type HumanName } from "fhir-zod/r4";
+```
+
+Import root helpers from the package root:
+
+```ts
+import { configureFhirString } from "fhir-zod";
+```
+
+## Rules to keep
+
+- Keep the FHIR release explicit in every import path.
+- Use the exported TypeScript model as the main application-facing type.
+- Use the exported Zod schema at runtime boundaries.
+- Prefer resource entry points for concrete resources to keep imports obvious.
+- Treat `z.output<typeof SomeSchema>` as an implementation detail, not the primary public model strategy.
+
+## Imports to avoid
+
+Do not import generated internal schema symbols:
+
+```ts
+// Avoid
+import { PatientSchemaInternal } from "fhir-zod/r4/Patient";
+```
+
+Do not import from generated source paths in application code:
+
+```ts
+// Avoid
+import { PatientSchema } from "../src/r4/Patient/Patient";
+```
+
+Do not mix releases in a single flow unless you are translating deliberately:
+
+```ts
+import type { Patient as R4Patient } from "fhir-zod/r4/Patient";
+import type { Patient as R5Patient } from "fhir-zod/r5/Patient";
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,85 @@
+---
+title: Getting Started
+description: Install the package, import generated models and schemas, and validate FHIR payloads.
+---
+
+# Getting Started
+
+Install `fhir-zod` alongside `zod`:
+
+```bash
+npm install fhir-zod zod
+```
+
+## Parse a concrete resource
+
+Use the generated TypeScript model for the data shape and the matching schema for runtime validation.
+
+```ts
+import { PatientSchema, type Patient } from "fhir-zod/r4/Patient";
+
+const patient: Patient = {
+  resourceType: "Patient",
+  id: "john-doe",
+  active: true,
+  name: [{ family: "Doe", given: ["John"] }],
+  gender: "male",
+  birthDate: "1985-03-15",
+};
+
+const result = PatientSchema.safeParse(patient);
+
+if (!result.success) {
+  console.error(result.error.issues);
+}
+```
+
+## Validate untrusted JSON
+
+Prefer `safeParse` when invalid input should stay in normal control flow.
+
+```ts
+import { ObservationSchema } from "fhir-zod/r4/Observation";
+
+const payload: unknown = await fetch("/api/observation").then((response) =>
+  response.json(),
+);
+
+const parsed = ObservationSchema.safeParse(payload);
+
+if (!parsed.success) {
+  throw new Error("Invalid R4 Observation payload");
+}
+```
+
+Use `parse` when invalid input should throw immediately.
+
+```ts
+import { BundleSchema, type Bundle } from "fhir-zod/r4/Bundle";
+
+const bundle: Bundle = {
+  resourceType: "Bundle",
+  type: "collection",
+  entry: [],
+};
+
+BundleSchema.parse(bundle);
+```
+
+## Configure empty FHIR string handling
+
+The root package exports shared helpers such as `configureFhirString`.
+
+```ts
+import { configureFhirString } from "fhir-zod";
+
+configureFhirString({ allowEmpty: true });
+```
+
+This setting is process-global and only changes validation for the FHIR `string` primitive.
+
+## Next steps
+
+- Use [FHIR Versions](/versions) to keep imports release-specific.
+- Use [API Conventions](/api-conventions) to understand `Patient` versus `PatientSchema`.
+- Use [Validation Scope](/validation-scope) to understand the structural checks the schemas enforce.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+---
+layout: home
+
+hero:
+  name: fhir-zod
+  text: Zod schemas for FHIR resources
+  tagline: Generated TypeScript models and runtime validators for HL7 FHIR.
+  actions:
+    - theme: brand
+      text: Getting Started
+      link: /getting-started
+    - theme: alt
+      text: GitHub
+      link: https://github.com/alysivji/fhir-zod
+---
+
+`fhir-zod` is a generated TypeScript library for working with HL7 FHIR shapes in application code.
+
+## Install
+
+```bash
+npm install fhir-zod zod
+```
+
+## Basic usage
+
+```ts
+import { PatientSchema, type Patient } from "fhir-zod/r4/Patient";
+
+const patient: Patient = {
+  resourceType: "Patient",
+  id: "john-doe",
+  active: true,
+  name: [{ family: "Doe", given: ["John"] }],
+  gender: "male",
+  birthDate: "1985-03-15",
+};
+
+const result = PatientSchema.safeParse(patient);
+
+if (!result.success) {
+  console.error(result.error.issues);
+}
+```
+
+## What you get
+
+- Generated TypeScript models such as `Patient`
+- Generated Zod schemas such as `PatientSchema`
+- Explicit versioned imports for STU3, R4, R4B, and R5
+- Spec-aligned output from pinned HL7 artifacts
+
+## Next steps
+
+- Start with [Getting Started](/getting-started) for install and validation examples.
+- Use [FHIR Versions](/versions) to keep imports release-specific.
+- Read [Validation Scope](/validation-scope) before relying on the schemas for non-structural checks.

--- a/docs/validation-scope.md
+++ b/docs/validation-scope.md
@@ -1,0 +1,29 @@
+---
+title: Validation Scope
+description: What the generated schemas validate, and what remains outside the scope of this library.
+---
+
+# Validation Scope
+
+`fhir-zod` focuses on structural FHIR validation.
+
+## Covered
+
+- Field presence and cardinality
+- FHIR primitive formatting
+- Enum and code literal unions generated from the spec
+- Choice-type exclusivity such as `value[x]`
+- Selected constrained reference targets
+
+## Not covered
+
+- Terminology validation
+- FHIRPath execution
+- Profile resolution
+- Slicing
+- FHIR server behavior
+- End-to-end clinical or regulatory correctness
+
+## Practical implication
+
+Use `fhir-zod` to validate the structural shape of data entering or leaving your system. If a workflow depends on terminology services, profile-aware validation, or server semantics, combine `fhir-zod` with other FHIR-specific tooling instead of stretching this package past its design target.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,28 @@
+---
+title: FHIR Versions
+description: Supported FHIR releases, versioned import paths, and links back to the canonical HL7 specification.
+---
+
+# Supported FHIR releases
+
+`fhir-zod` keeps each FHIR release on an explicit import path. Pick one release for a given model flow and keep the types and schemas on that same path.
+
+| FHIR release | Version entry point | Resource entry points | Canonical HL7 docs |
+| --- | --- | --- | --- |
+| STU3 | `fhir-zod/stu3` | `fhir-zod/stu3/<Resource>` | [HL7 STU3](https://hl7.org/fhir/STU3) |
+| R4 | `fhir-zod/r4` | `fhir-zod/r4/<Resource>` | [HL7 R4](https://hl7.org/fhir/R4) |
+| R4B | `fhir-zod/r4b` | `fhir-zod/r4b/<Resource>` | [HL7 R4B](https://hl7.org/fhir/R4B) |
+| R5 | `fhir-zod/r5` | `fhir-zod/r5/<Resource>` | [HL7 R5](https://hl7.org/fhir/R5) |
+
+## Import rules
+
+- Use one release consistently in a given parsing or modeling flow.
+- Import shared datatypes from the version entry point when that is sufficient.
+- Import concrete resources from resource entry points such as `fhir-zod/r4/Patient`.
+- Do not mix STU3, R4, R4B, and R5 types unless your code explicitly translates between releases.
+
+## Support status
+
+- STU3, R4, R4B, and R5 generation are implemented and checked in on this branch.
+- The package is still pre-release, so package shape and generated output may change between releases.
+- Package orientation lives here; full semantic meaning still belongs to the official HL7 FHIR specification for each release.

--- a/justfile
+++ b/justfile
@@ -14,6 +14,14 @@ install:
 build:
     npm run build
 
+# Build the docs site
+build-docs:
+    npm run docs:build
+
+# Run the docs site locally
+docs-dev:
+    npm run docs:dev
+
 # Run the test suite
 test:
     npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"tsdown": "^0.15.5",
 				"tsx": "^4.21.0",
 				"typescript": "^5.8.2",
+				"vitepress": "^1.6.4",
 				"vitest": "^3.1.1",
 				"zod": "^3.25.1 || ^4.0.0"
 			},
@@ -93,6 +94,265 @@
 			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@algolia/abtesting": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
+			"integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/autocomplete-core": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+			"integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+				"@algolia/autocomplete-shared": "1.17.7"
+			}
+		},
+		"node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+			"integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-shared": "1.17.7"
+			},
+			"peerDependencies": {
+				"search-insights": ">= 1 < 3"
+			}
+		},
+		"node_modules/@algolia/autocomplete-preset-algolia": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+			"integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-shared": "1.17.7"
+			},
+			"peerDependencies": {
+				"@algolia/client-search": ">= 4.9.1 < 6",
+				"algoliasearch": ">= 4.9.1 < 6"
+			}
+		},
+		"node_modules/@algolia/autocomplete-shared": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+			"integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@algolia/client-search": ">= 4.9.1 < 6",
+				"algoliasearch": ">= 4.9.1 < 6"
+			}
+		},
+		"node_modules/@algolia/client-abtesting": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
+			"integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-analytics": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
+			"integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-common": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
+			"integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-insights": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
+			"integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-personalization": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
+			"integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-query-suggestions": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
+			"integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/client-search": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
+			"integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/ingestion": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
+			"integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/monitoring": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
+			"integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/recommend": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
+			"integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/requester-browser-xhr": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
+			"integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/requester-fetch": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
+			"integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@algolia/requester-node-http": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
+			"integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/client-common": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -396,6 +656,57 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@docsearch/css": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+			"integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@docsearch/js": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+			"integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@docsearch/react": "3.8.2",
+				"preact": "^10.0.0"
+			}
+		},
+		"node_modules/@docsearch/react": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+			"integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@algolia/autocomplete-core": "1.17.7",
+				"@algolia/autocomplete-preset-algolia": "1.17.7",
+				"@docsearch/css": "3.8.2",
+				"algoliasearch": "^5.14.2"
+			},
+			"peerDependencies": {
+				"@types/react": ">= 16.8.0 < 19.0.0",
+				"react": ">= 16.8.0 < 19.0.0",
+				"react-dom": ">= 16.8.0 < 19.0.0",
+				"search-insights": ">= 1 < 3"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"search-insights": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -873,6 +1184,23 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/@iconify-json/simple-icons": {
+			"version": "1.2.79",
+			"resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.79.tgz",
+			"integrity": "sha512-aNyO7Fd1qej9oQfIyohYFRv0lhQLaZ+6UkK1c1qwax0MDPUOZOdq65MlU500kow97pD/W+b2u1And3e25eE24Q==",
+			"dev": true,
+			"license": "CC0-1.0",
+			"dependencies": {
+				"@iconify/types": "*"
+			}
+		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -1726,6 +2054,93 @@
 				"win32"
 			]
 		},
+		"node_modules/@shikijs/core": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+			"integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-javascript": "2.5.0",
+				"@shikijs/engine-oniguruma": "2.5.0",
+				"@shikijs/types": "2.5.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.4"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+			"integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "2.5.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^3.1.0"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+			"integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "2.5.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+			"integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "2.5.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+			"integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "2.5.0"
+			}
+		},
+		"node_modules/@shikijs/transformers": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+			"integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "2.5.0",
+				"@shikijs/types": "2.5.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+			"integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1762,6 +2177,51 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -1771,6 +2231,41 @@
 			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/web-bluetooth": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@vitejs/plugin-vue": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+			"integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^5.0.0 || ^6.0.0",
+				"vue": "^3.2.25"
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
@@ -1922,6 +2417,271 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vue/compiler-core": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+			"integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.2",
+				"@vue/shared": "3.5.33",
+				"entities": "^7.0.1",
+				"estree-walker": "^2.0.2",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/@vue/compiler-core/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vue/compiler-dom": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+			"integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/compiler-core": "3.5.33",
+				"@vue/shared": "3.5.33"
+			}
+		},
+		"node_modules/@vue/compiler-sfc": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+			"integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.2",
+				"@vue/compiler-core": "3.5.33",
+				"@vue/compiler-dom": "3.5.33",
+				"@vue/compiler-ssr": "3.5.33",
+				"@vue/shared": "3.5.33",
+				"estree-walker": "^2.0.2",
+				"magic-string": "^0.30.21",
+				"postcss": "^8.5.10",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vue/compiler-ssr": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+			"integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/compiler-dom": "3.5.33",
+				"@vue/shared": "3.5.33"
+			}
+		},
+		"node_modules/@vue/devtools-api": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+			"integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-kit": "^7.7.9"
+			}
+		},
+		"node_modules/@vue/devtools-kit": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+			"integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-shared": "^7.7.9",
+				"birpc": "^2.3.0",
+				"hookable": "^5.5.3",
+				"mitt": "^3.0.1",
+				"perfect-debounce": "^1.0.0",
+				"speakingurl": "^14.0.1",
+				"superjson": "^2.2.2"
+			}
+		},
+		"node_modules/@vue/devtools-shared": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+			"integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"rfdc": "^1.4.1"
+			}
+		},
+		"node_modules/@vue/reactivity": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+			"integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/shared": "3.5.33"
+			}
+		},
+		"node_modules/@vue/runtime-core": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+			"integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/reactivity": "3.5.33",
+				"@vue/shared": "3.5.33"
+			}
+		},
+		"node_modules/@vue/runtime-dom": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+			"integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/reactivity": "3.5.33",
+				"@vue/runtime-core": "3.5.33",
+				"@vue/shared": "3.5.33",
+				"csstype": "^3.2.3"
+			}
+		},
+		"node_modules/@vue/server-renderer": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+			"integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vue/compiler-ssr": "3.5.33",
+				"@vue/shared": "3.5.33"
+			},
+			"peerDependencies": {
+				"vue": "3.5.33"
+			}
+		},
+		"node_modules/@vue/shared": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+			"integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vueuse/core": {
+			"version": "12.8.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+			"integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/web-bluetooth": "^0.0.21",
+				"@vueuse/metadata": "12.8.2",
+				"@vueuse/shared": "12.8.2",
+				"vue": "^3.5.13"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@vueuse/integrations": {
+			"version": "12.8.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+			"integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vueuse/core": "12.8.2",
+				"@vueuse/shared": "12.8.2",
+				"vue": "^3.5.13"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"async-validator": "^4",
+				"axios": "^1",
+				"change-case": "^5",
+				"drauu": "^0.4",
+				"focus-trap": "^7",
+				"fuse.js": "^7",
+				"idb-keyval": "^6",
+				"jwt-decode": "^4",
+				"nprogress": "^0.2",
+				"qrcode": "^1.5",
+				"sortablejs": "^1",
+				"universal-cookie": "^7"
+			},
+			"peerDependenciesMeta": {
+				"async-validator": {
+					"optional": true
+				},
+				"axios": {
+					"optional": true
+				},
+				"change-case": {
+					"optional": true
+				},
+				"drauu": {
+					"optional": true
+				},
+				"focus-trap": {
+					"optional": true
+				},
+				"fuse.js": {
+					"optional": true
+				},
+				"idb-keyval": {
+					"optional": true
+				},
+				"jwt-decode": {
+					"optional": true
+				},
+				"nprogress": {
+					"optional": true
+				},
+				"qrcode": {
+					"optional": true
+				},
+				"sortablejs": {
+					"optional": true
+				},
+				"universal-cookie": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vueuse/metadata": {
+			"version": "12.8.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+			"integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@vueuse/shared": {
+			"version": "12.8.2",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+			"integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vue": "^3.5.13"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1933,6 +2693,33 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/algoliasearch": {
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
+			"integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@algolia/abtesting": "1.17.0",
+				"@algolia/client-abtesting": "5.51.0",
+				"@algolia/client-analytics": "5.51.0",
+				"@algolia/client-common": "5.51.0",
+				"@algolia/client-insights": "5.51.0",
+				"@algolia/client-personalization": "5.51.0",
+				"@algolia/client-query-suggestions": "5.51.0",
+				"@algolia/client-search": "5.51.0",
+				"@algolia/ingestion": "1.51.0",
+				"@algolia/monitoring": "1.51.0",
+				"@algolia/recommend": "5.51.0",
+				"@algolia/requester-browser-xhr": "5.51.0",
+				"@algolia/requester-fetch": "5.51.0",
+				"@algolia/requester-node-http": "5.51.0"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -2080,6 +2867,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chai": {
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2128,6 +2926,28 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/check-error": {
@@ -2270,6 +3090,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/commander": {
 			"version": "14.0.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2278,6 +3109,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/copy-anything": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-what": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -2294,6 +3141,13 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -2329,6 +3183,30 @@
 			"integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/diff": {
 			"version": "8.0.4",
@@ -2375,6 +3253,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/emoji-regex-xs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+			"integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/empathic": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -2383,6 +3268,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/es-module-lexer": {
@@ -2512,6 +3410,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/focus-trap": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+			"integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tabbable": "^6.4.0"
+			}
+		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2632,6 +3541,44 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hookable": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -2645,6 +3592,17 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -2664,6 +3622,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-what": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mesqueeb"
 			}
 		},
 		"node_modules/isexe": {
@@ -2832,6 +3803,129 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/mark.js": {
+			"version": "8.11.1",
+			"resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+			"integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -2885,6 +3979,20 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/minisearch": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+			"integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mitt": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2921,6 +4029,18 @@
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+			"integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex-xs": "^1.0.0",
+				"regex": "^6.0.1",
+				"regex-recursion": "^6.0.2"
+			}
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
@@ -2973,6 +4093,13 @@
 				"node": ">= 14.16"
 			}
 		},
+		"node_modules/perfect-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2995,9 +4122,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
 			"dev": true,
 			"funding": [
 				{
@@ -3021,6 +4148,28 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/preact": {
+			"version": "10.29.1",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+			"integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/property-information": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+			"integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/quansync": {
@@ -3054,6 +4203,33 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3073,6 +4249,13 @@
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-beta.45",
@@ -3198,6 +4381,14 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/search-insights": {
+			"version": "2.17.3",
+			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3234,6 +4425,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shiki": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+			"integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "2.5.0",
+				"@shikijs/engine-javascript": "2.5.0",
+				"@shikijs/engine-oniguruma": "2.5.0",
+				"@shikijs/langs": "2.5.0",
+				"@shikijs/themes": "2.5.0",
+				"@shikijs/types": "2.5.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3258,6 +4466,27 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/speakingurl": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -3342,6 +4571,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -3395,6 +4639,19 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/superjson": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"copy-anything": "^4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3407,6 +4664,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/test-exclude": {
 			"version": "7.0.2",
@@ -3507,6 +4771,17 @@
 				"tree-kill": "cli.js"
 			}
 		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/tsdown": {
 			"version": "0.15.12",
 			"resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.15.12.tgz",
@@ -3591,7 +4866,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -3679,6 +4953,79 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/universal-user-agent": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
@@ -3700,26 +5047,53 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/vite": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+			"version": "5.4.21",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
+				"esbuild": "^0.21.3",
+				"postcss": "^8.4.43",
+				"rollup": "^4.20.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3728,23 +5102,17 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"less": "*",
 				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.4.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
-					"optional": true
-				},
-				"jiti": {
 					"optional": true
 				},
 				"less": {
@@ -3766,12 +5134,6 @@
 					"optional": true
 				},
 				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
 					"optional": true
 				}
 			}
@@ -3797,6 +5159,478 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+			"integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+			"integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+			"integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+			"integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+			"integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+			"integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+			"integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-arm": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+			"integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+			"integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+			"integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+			"integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+			"integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+			"integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+			"integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+			"integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+			"integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+			"integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+			"integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+			"integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+			"integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/win32-x64": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+			"integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.21.5",
+				"@esbuild/android-arm": "0.21.5",
+				"@esbuild/android-arm64": "0.21.5",
+				"@esbuild/android-x64": "0.21.5",
+				"@esbuild/darwin-arm64": "0.21.5",
+				"@esbuild/darwin-x64": "0.21.5",
+				"@esbuild/freebsd-arm64": "0.21.5",
+				"@esbuild/freebsd-x64": "0.21.5",
+				"@esbuild/linux-arm": "0.21.5",
+				"@esbuild/linux-arm64": "0.21.5",
+				"@esbuild/linux-ia32": "0.21.5",
+				"@esbuild/linux-loong64": "0.21.5",
+				"@esbuild/linux-mips64el": "0.21.5",
+				"@esbuild/linux-ppc64": "0.21.5",
+				"@esbuild/linux-riscv64": "0.21.5",
+				"@esbuild/linux-s390x": "0.21.5",
+				"@esbuild/linux-x64": "0.21.5",
+				"@esbuild/netbsd-x64": "0.21.5",
+				"@esbuild/openbsd-x64": "0.21.5",
+				"@esbuild/sunos-x64": "0.21.5",
+				"@esbuild/win32-arm64": "0.21.5",
+				"@esbuild/win32-ia32": "0.21.5",
+				"@esbuild/win32-x64": "0.21.5"
+			}
+		},
+		"node_modules/vitepress": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+			"integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@docsearch/css": "3.8.2",
+				"@docsearch/js": "3.8.2",
+				"@iconify-json/simple-icons": "^1.2.21",
+				"@shikijs/core": "^2.1.0",
+				"@shikijs/transformers": "^2.1.0",
+				"@shikijs/types": "^2.1.0",
+				"@types/markdown-it": "^14.1.2",
+				"@vitejs/plugin-vue": "^5.2.1",
+				"@vue/devtools-api": "^7.7.0",
+				"@vue/shared": "^3.5.13",
+				"@vueuse/core": "^12.4.0",
+				"@vueuse/integrations": "^12.4.0",
+				"focus-trap": "^7.6.4",
+				"mark.js": "8.11.1",
+				"minisearch": "^7.1.1",
+				"shiki": "^2.1.0",
+				"vite": "^5.4.14",
+				"vue": "^3.5.13"
+			},
+			"bin": {
+				"vitepress": "bin/vitepress.js"
+			},
+			"peerDependencies": {
+				"markdown-it-mathjax3": "^4",
+				"postcss": "^8"
+			},
+			"peerDependenciesMeta": {
+				"markdown-it-mathjax3": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vitest": {
@@ -3869,6 +5703,29 @@
 					"optional": true
 				},
 				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vue": {
+			"version": "3.5.33",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+			"integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@vue/compiler-dom": "3.5.33",
+				"@vue/compiler-sfc": "3.5.33",
+				"@vue/runtime-dom": "3.5.33",
+				"@vue/server-renderer": "3.5.33",
+				"@vue/shared": "3.5.33"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
 					"optional": true
 				}
 			}
@@ -4103,6 +5960,17 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
 		"check": "biome check . && npm run typecheck",
 		"check:resource-folders": "tsx scripts/check-resource-folders.ts",
 		"codecov:bundle": "bundle-analyzer ./dist --bundle-name=fhir-zod --ignore-patterns '**/*.map' --upload-token=$BUNDLE_ANALYZER_UPLOAD_TOKEN",
+		"docs:build": "vitepress build docs",
+		"docs:dev": "vitepress dev docs",
+		"docs:preview": "npm run docs:build && vitepress preview docs",
+		"docs:validate": "npm run docs:build",
 		"coverage": "vitest run --coverage",
 		"cli": "tsx scripts/cli.ts",
 		"fetch-examples": "tsx scripts/cli.ts fetch-examples",
@@ -111,6 +115,7 @@
 		"tsdown": "^0.15.5",
 		"tsx": "^4.21.0",
 		"typescript": "^5.8.2",
+		"vitepress": "^1.6.4",
 		"vitest": "^3.1.1",
 		"zod": "^3.25.1 || ^4.0.0"
 	}

--- a/src/generator/versions.ts
+++ b/src/generator/versions.ts
@@ -189,6 +189,10 @@ export abstract class FhirRelease {
 		return `${this.specBaseUrl()}/${resourceName.toLowerCase()}-examples.html`;
 	}
 
+	specHomeUrl(): string {
+		return this.specBaseUrl();
+	}
+
 	sourcePageUrl(options: {
 		fhirPath?: string;
 		kind: string;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run docs:build",
+  "outputDirectory": "docs/.vitepress/dist"
+}


### PR DESCRIPTION
# Summary

Start #37.

Add a VitePress documentation site for `fhir-zod` and wire it into local development and Vercel deployment. The docs include package orientation pages and built-in local search so the site is immediately usable without external search infrastructure.

## Changes

- Add a VitePress docs site under `docs/` with home, getting started, versioning, API conventions, and validation scope pages.
- Add docs scripts to `package.json`, matching `justfile` helpers, and a `vercel.json` output configuration for static deployment.
- Enable VitePress local search in the site config and add a small `specHomeUrl()` helper on `FhirRelease` to support docs links back to the canonical HL7 specification.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

```bash
npm run docs:build
```

## Docs

- [ ] No docs update needed
- [x] Docs updated

_Created with Codex._
