### PR TITLE
Point npm package at docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 dist/
 /coverage/
 test-results/
+/.vitepress/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
 .context/
 .local/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Supports Node.js 20+ and modern bundlers. Import concrete resources from resourc
 
 ## Documentation
 
-The docs site for package usage and validation boundaries is published from this repo's VitePress app. The source lives in [`docs/`](./docs/). Preview it locally with:
+Browse the package docs at <https://fhir-zod.vercel.app/>.
+
+The VitePress source for package usage and validation boundaries lives in [`docs/`](./docs/). Preview it locally with:
 
 ```bash
 npm run docs:dev

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
 	title: "fhir-zod",
 	description: "Spec-aligned TypeScript models and runtime validators for HL7 FHIR.",
+	cleanUrls: true,
 	head: [
 		[
 			"script",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"bugs": {
 		"url": "https://github.com/alysivji/fhir-zod/issues"
 	},
-	"homepage": "https://github.com/alysivji/fhir-zod#readme",
+	"homepage": "https://fhir-zod.vercel.app/",
 	"keywords": [
 		"fhir",
 		"hl7",

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "buildCommand": "npm run docs:build",
   "outputDirectory": "docs/.vitepress/dist"
 }


### PR DESCRIPTION
# Summary

Point npm users at the published docs site instead of the GitHub README and align the docs routing config with that deployment. This makes the package metadata more useful and keeps VitePress and Vercel on the same clean-URL path shape.

## Changes

- Update `package.json` `homepage` to `https://fhir-zod.vercel.app/` so npm points users to the live docs.
- Update the README documentation section to link directly to the published docs site.
- Enable `cleanUrls` in both `docs/.vitepress/config.ts` and `vercel.json` so generated links and deployed routes use the same extensionless path shape.
- Ignore stray VitePress cache and build output paths in `.gitignore` to avoid accidental top-level `.vitepress/` artifacts in the worktree.

## API Or Breaking Changes

- [x] No public API changes
- [ ] Public API added or changed
- [ ] Breaking change

## Testing

List the commands you ran:

```bash
npm run docs:build
```

`npm run docs:build` passed.

## Docs

- [ ] No docs update needed
- [x] Docs updated

_Created with Codex._
